### PR TITLE
Fix installation the gem

### DIFF
--- a/querly.gemspec
+++ b/querly.gemspec
@@ -13,7 +13,10 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Write a longer description or delete this line.}
   spec.homepage      = "https://github.com/soutaro/querly"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`
+    .split("\x0")
+    .reject { |f| f.match(%r{^(test|spec|features)/}) }
+    .push('lib/querly/pattern/parser.rb')
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
@@ -21,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "racc", "= 1.4.14"
 
   spec.add_dependency 'thor', "~> 0.19"
   spec.add_dependency "parser", "~> 2.3.1"


### PR DESCRIPTION
Problem 1
----

First, I've grabbed an error of `racc` when run `rake racc`


```sh
$ bundle exec rake racc
racc -v -o lib/querly/pattern/parser.rb lib/querly/pattern/parser.y
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.12.5/lib/bundler/rubygems_integration.rb:322:in `block in replace_gem': racc is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
        from /home/pocke/.gem/ruby/2.3.0/bin/racc:22:in `<main>'
rake aborted!
Command failed with status (1): [racc -v -o lib/querly/pattern/parser.rb li...]
/home/pocke/ghq/github.com/soutaro/querly/Rakefile:15:in `block in <top (required)>'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:63:in `load'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:63:in `kernel_load'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:24:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.12.5/lib/bundler/cli.rb:304:in `exec'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.12.5/lib/bundler/cli.rb:11:in `start'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.12.5/exe/bundle:27:in `block in <top (required)>'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.12.5/lib/bundler/friendly_errors.rb:98:in `with_friendly_errors'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.12.5/exe/bundle:19:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/bin//bundle:23:in `load'
/home/pocke/.gem/ruby/2.3.0/bin//bundle:23:in `<main>'
Tasks: TOP => racc => lib/querly/pattern/parser.rb
(See full trace by running task with --trace)
```


Solution 1
----

I've added a dependency of racc gem.


Problem 2
-----

I've grabbed an error of missing file when run `querly`

```sh
$ bundle exec rake install
$ querly
/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- querly/pattern/parser (LoadError)
        from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /home/pocke/.gem/ruby/2.3.0/gems/querly-0.1.0/lib/querly.rb:14:in `<top (required)>'
        from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:68:in `require'
        from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:68:in `require'
        from /home/pocke/.gem/ruby/2.3.0/gems/querly-0.1.0/exe/querly:5:in `<top (required)>'
        from /home/pocke/.gem/ruby/2.3.0/bin//querly:23:in `load'
        from /home/pocke/.gem/ruby/2.3.0/bin//querly:23:in `<main>'
```

Solution 2
-------

I've added a generated ruby code(`parser.rb`) into installed files list for gem.