### PR TITLE
Require Rules from Ruby Script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 0.3.0
 
+* Allow `require` rules from config file
 * Add `version` command
 * Fix *with block* and *without block* pattern parsing
 * Prettier backtrace printing

--- a/README.md
+++ b/README.md
@@ -94,6 +94,27 @@ Visit our wiki pages for configuration and query language reference.
 
 Use `querly console` command to test patterns interactively.
 
+## Requiring Rules
+
+`import` section in config file now allows accepts `require` command.
+
+```yaml
+import:
+  - require: querly/rules/sample
+  - require: your_library/querly/rules
+```
+
+Querly ships with `querly/rules/sample` rule set. Check `lib/querly/rules/sample.rb` and `rules/sample.yml` for detail.
+
+### Publishing Gems with Querly Rules
+
+Querly provides `Querly.load_rule` API to allow publishing your rules as part of Ruby library.
+Put rules YAML file in your gem, and add Ruby script in some directory like `lib/your_library/querly/rules.rb`.
+
+```
+Querly.load_rules File.join(__dir__, relative_path_to_yaml_file)
+```
+
 ## Notes
 
 ### Querly's analysis is syntactic

--- a/lib/querly.rb
+++ b/lib/querly.rb
@@ -23,5 +23,18 @@ require "querly/check"
 require "querly/concerns/backtrace_formatter"
 
 module Querly
-  # Your code goes here...
+  @@required_rules = []
+
+  def self.required_rules
+    @@required_rules
+  end
+
+  def self.load_rule(*files)
+    files.each do |file|
+      path = Pathname(file)
+      yaml = YAML.load(path.read)
+      rules = yaml.map {|hash| Rule.load(hash) }
+      required_rules.concat rules
+    end
+  end
 end

--- a/lib/querly/config.rb
+++ b/lib/querly/config.rb
@@ -77,7 +77,14 @@ module Querly
               end
             end
           end
+
+          if import["require"]
+            stderr.puts "Require rules from #{import["require"]}..."
+            require import["require"]
+          end
         end
+
+        rules.concat Querly.required_rules
 
         checks = Array(yaml["check"]).map {|hash| Check.load(hash) }
 

--- a/lib/querly/rules/sample.rb
+++ b/lib/querly/rules/sample.rb
@@ -1,0 +1,1 @@
+Querly.load_rule File.join(__dir__, "../../../rules/sample.yml")

--- a/rules/sample.yml
+++ b/rules/sample.yml
@@ -1,0 +1,34 @@
+- id: sample.ruby.pathname
+  pattern: Pathname.new
+  message: |
+    Did you mean `Pathname` method?
+
+- id: sample.ruby.file.dir
+  pattern: "File.dirname(:string:)"
+  message: |
+    Did you mean `__dir__`?
+
+- id: sample.ruby.file.open
+  pattern: File.open(...) !{}
+  message: |
+    Using block is better in Ruby
+
+- id: sample.ruby.debug_print
+  pattern:
+    - self.p
+    - self.pp
+  message: |
+    Delete debug print
+
+- id: sample.ruby.clone
+  pattern:
+    - clone()
+    - "clone(!freeze: _)"
+  message: |
+    Did you mean `dup`?
+
+    `clone` returns frozen object when receiver is frozen.
+
+    * If object is frozen, you usually does not need to clone it
+    * When you need a copy of a object, you provablly want to modify that; did you mean dup?
+    * Ruby 2.4 accepts freeze keyword and returns not frozen object

--- a/sample.yaml
+++ b/sample.yaml
@@ -130,7 +130,8 @@ preprocessor:
   .slim: slimrb --compile
 
 import:
-  - load: rules/*.yml
+  - load: querly/rules/*.yml
+  - require: querly/rules/sample
 
 check:
   - path: /


### PR DESCRIPTION
* Allow publishing your rules as Ruby script
* Add `require` command for rules

Example configuration:

```yaml
import:
  - require: querly/rules/sample
  - require: your_library/querly/rules
```