### PR TITLE
Prevent failure test due to environmental dependence

### DIFF
--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -92,7 +92,7 @@ class ConfigTest < Minitest::Test
 
       config = Config.load(YAML.load(path.read), config_path: path, root_dir: path, stderr: stderr)
 
-      assert_equal ["rule1", "rule2", "rule3", "rule4"], config.rules.map(&:id)
+      assert_equal ["rule1", "rule2", "rule3", "rule4"], config.rules.map(&:id).sort
     end
   end
 


### PR DESCRIPTION
`test_loading_rules_from_file` test is failed in my environment.

```
$ bundle exec rake
Run options: --seed 62459

 # Running:

...................F.......................................................................................

Finished in 4.031457s, 26.5413 runs/s, 70.9421 assertions/s.

  1) Failure:
ConfigTest#test_loading_rules_from_file [/home/pocke/ghq/github.com/soutaro/querly/test/config_test.rb:95]:
--- expected
+++ actual
@@ -1 +1 @@
-["rule1", "rule2", "rule3", "rule4"]
+["rule1", "rule3", "rule4", "rule2"]

107 runs, 286 assertions, 1 failures, 0 errors, 0 skips
```

The order of values returned by `Pathname.glob` depends on system.

> Note that this pattern is not a regexp, it’s closer to a shell glob. See File.fnmatch for the meaning of the flags parameter. Note that case sensitivity depends on your system (so File::FNM_CASEFOLD is ignored), as does the order in which the results are returned.
> https://ruby-doc.org/core-2.4.0/Dir.html#method-c-glob


`Pathname.glob` uses `Dir.glob`.