### PR TITLE
Use human readable index for error message

### DIFF
--- a/lib/querly/cli/test.rb
+++ b/lib/querly/cli/test.rb
@@ -67,7 +67,7 @@ module Querly
         errors = 0
 
         rules.each do |rule|
-          rule.before_examples.each.with_index do |example, example_index|
+          rule.before_examples.each.with_index(1) do |example, example_index|
             tests += 1
 
             begin
@@ -81,7 +81,7 @@ module Querly
             end
           end
 
-          rule.after_examples.each.with_index do |example, example_index|
+          rule.after_examples.each.with_index(1) do |example, example_index|
             tests += 1
 
             begin

--- a/test/cli/test_test.rb
+++ b/test/cli/test_test.rb
@@ -109,8 +109,8 @@ class TestTest < Minitest::Test
     result = test.run
 
     assert_equal 1, result
-    assert_match /id1:\t0th \*before\* example didn't match with any pattern/, stdout.string
-    assert_match /id1:\t0th \*after\* example matched with some of patterns/, stdout.string
+    assert_match /id1:\t1th \*before\* example didn't match with any pattern/, stdout.string
+    assert_match /id1:\t1th \*after\* example matched with some of patterns/, stdout.string
     assert_match /1 examples found which should not match, but matched/, stdout.string
     assert_match /1 examples found which should match, but didn't/, stdout.string
   end


### PR DESCRIPTION
querly.yaml
-------------

```yaml
rules:
  - id: foo
    pattern:
      - "bad()"
    before:
      - 'good()'
      - 'bad()'
    after:
      - 'good()'
    message: 'Do not use bad()'
```

before
----------

```bash
$ querly test
Checking rule id uniqueness...
Checking rule patterns...
  foo:	0th *before* example didn't match with any pattern
Tested 1 rules with 3 tests.
  0 examples found which should not match, but matched
  1 examples found which should match, but didn't
  0 examples raised error
```

`0th`

after
------------

```bash
$ querly test
Checking rule id uniqueness...
Checking rule patterns...
  foo:	1th *before* example didn't match with any pattern
Tested 1 rules with 3 tests.
  0 examples found which should not match, but matched
  1 examples found which should match, but didn't
  0 examples raised error
```

`1th`