### PR TITLE
Ordinalize example index using ActiveSupport

### DIFF
--- a/lib/querly.rb
+++ b/lib/querly.rb
@@ -4,6 +4,7 @@ require "rainbow"
 require "parser/current"
 require "set"
 require "open3"
+require "active_support/inflector"
 
 Parser::Builders::Default.emit_lambda = true
 

--- a/lib/querly/cli/test.rb
+++ b/lib/querly/cli/test.rb
@@ -72,12 +72,12 @@ module Querly
 
             begin
               unless rule.patterns.any? {|pat| test_pattern(pat, example, expected: true) }
-                stdout.puts(Rainbow("  #{rule.id}").red + ":\t#{example_index}th *before* example didn't match with any pattern")
+                stdout.puts(Rainbow("  #{rule.id}").red + ":\t#{ordinalize example_index} *before* example didn't match with any pattern")
                 false_negatives += 1
               end
             rescue Parser::SyntaxError
               errors += 1
-              stdout.puts(Rainbow("  #{rule.id}").red + ":\tParsing failed for #{example_index}th *before* example")
+              stdout.puts(Rainbow("  #{rule.id}").red + ":\tParsing failed for #{ordinalize example_index} *before* example")
             end
           end
 
@@ -86,12 +86,12 @@ module Querly
 
             begin
               unless rule.patterns.all? {|pat| test_pattern(pat, example, expected: false) }
-                stdout.puts(Rainbow("  #{rule.id}").red + ":\t#{example_index}th *after* example matched with some of patterns")
+                stdout.puts(Rainbow("  #{rule.id}").red + ":\t#{ordinalize example_index} *after* example matched with some of patterns")
                 false_positives += 1
               end
             rescue Parser::SyntaxError
               errors += 1
-              stdout.puts(Rainbow("  #{rule.id}") + ":\tParsing failed for #{example_index}th *after* example")
+              stdout.puts(Rainbow("  #{rule.id}") + ":\tParsing failed for #{ordinalize example_index} *after* example")
             end
           end
         end
@@ -127,6 +127,10 @@ module Querly
           yaml = YAML.load(config_path.read)
           Config.load(yaml, config_path: config_path, root_dir: config_path.parent.realpath, stderr: STDERR)
         end
+      end
+
+      def ordinalize(number)
+        ActiveSupport::Inflector.ordinalize(number)
       end
     end
   end

--- a/querly.gemspec
+++ b/querly.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor', "~> 0.19"
   spec.add_dependency "parser", "~> 2.4.0"
   spec.add_dependency "rainbow", "~> 2.1"
+  spec.add_dependency "activesupport", "~> 5.1.1"
 end

--- a/test/cli/test_test.rb
+++ b/test/cli/test_test.rb
@@ -109,8 +109,8 @@ class TestTest < Minitest::Test
     result = test.run
 
     assert_equal 1, result
-    assert_match /id1:\t1th \*before\* example didn't match with any pattern/, stdout.string
-    assert_match /id1:\t1th \*after\* example matched with some of patterns/, stdout.string
+    assert_match /id1:\t1st \*before\* example didn't match with any pattern/, stdout.string
+    assert_match /id1:\t1st \*after\* example matched with some of patterns/, stdout.string
     assert_match /1 examples found which should not match, but matched/, stdout.string
     assert_match /1 examples found which should match, but didn't/, stdout.string
   end


### PR DESCRIPTION
Ordinal forms looks like more human readable 🤝 

```
Checking rule patterns...
  sample.order-group:	1st *before* example didn't match with any pattern
  sample.order-group:	2nd *before* example didn't match with any pattern
```