### PR TITLE
Examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Exit 1 on test failure #9
 * Fix example index printing in test (@pocke) #8, #10
 * Introduce pattern matching on method name by set of string and regexp
+* Rule definitions in config can have more structured `examples` attribute
 
 ## 0.4.0 (2017-05-25)
 

--- a/lib/querly/cli/formatter.rb
+++ b/lib/querly/cli/formatter.rb
@@ -122,6 +122,12 @@ module Querly
                     id: rule.id,
                     messages: rule.messages,
                     justifications: rule.justifications,
+                    examples: rule.examples.map {|example|
+                      {
+                        before: example.before,
+                        after: example.after
+                      }
+                    }
                   },
                   location: {
                     start: [pair.node.loc.first_line, pair.node.loc.column],

--- a/lib/querly/cli/test.rb
+++ b/lib/querly/cli/test.rb
@@ -94,6 +94,34 @@ module Querly
               stdout.puts(Rainbow("  #{rule.id}") + ":\tParsing failed for #{ordinalize example_index} *after* example")
             end
           end
+
+          rule.examples.each.with_index(1) do |example, index|
+            if example.before
+              tests += 1
+              begin
+                unless rule.patterns.any? {|pat| test_pattern(pat, example.before, expected: true) }
+                  stdout.puts(Rainbow("  #{rule.id}").red + ":\tbefore of #{ordinalize index} example didn't match with any pattern")
+                  false_negatives += 1
+                end
+              rescue Parser::SyntaxError
+                errors += 1
+                stdout.puts(Rainbow("  #{rule.id}").red + ":\tParsing failed on before of #{ordinalize index} example")
+              end
+            end
+
+            if example.after
+              tests += 1
+              begin
+                unless rule.patterns.all? {|pat| test_pattern(pat, example.after, expected: false) }
+                  stdout.puts(Rainbow("  #{rule.id}").red + ":\tafter of #{ordinalize index} example matched with some of patterns")
+                  false_positives += 1
+                end
+              rescue Parser::SyntaxError
+                errors += 1
+                stdout.puts(Rainbow("  #{rule.id}") + ":\tParsing failed on after of #{ordinalize index} example")
+              end
+            end
+          end
         end
 
         stdout.puts "Tested #{rules.size} rules with #{tests} tests."

--- a/sample.yaml
+++ b/sample.yaml
@@ -134,6 +134,17 @@ rules:
       - subject: "'p(...)"
         where:
           p: /p+/
+  - id: sample.count
+    pattern: count() !{}
+    message: |
+      Use size or length for count, if receiver is an array
+    examples:
+      - before: "[].count"
+        after: "[].size"
+      - after: "[].count(:x)"
+      - after: "[].count {|x| x > 3 }"
+      - before: "[].count(x)"
+        after: "[].count"
 
 preprocessor:
   .slim: slimrb --compile

--- a/test/check_test.rb
+++ b/test/check_test.rb
@@ -85,7 +85,7 @@ class CheckTest < Minitest::Test
   end
 
   def test_query_match
-    rule = Rule.new(id: "ruby.pathname", messages: nil, patterns: nil, sources: nil, tags: Set.new(["tag1", "tag2"]), before_examples: [], after_examples: [], justifications: [])
+    rule = Rule.new(id: "ruby.pathname", messages: nil, patterns: nil, sources: nil, tags: Set.new(["tag1", "tag2"]), before_examples: [], after_examples: [], justifications: [], examples: [])
 
     assert Check::Query.new(:append, nil, "ruby.pathname").match?(rule)
     assert Check::Query.new(:append, nil, "ruby").match?(rule)
@@ -101,8 +101,8 @@ class CheckTest < Minitest::Test
   end
 
   def test_query_apply
-    r1 = Rule.new(id: "ruby.pathname", messages: nil, patterns: nil, sources: nil, tags: Set.new(), before_examples: [], after_examples: [], justifications: [])
-    r2 = Rule.new(id: "minitest.assert", messages: nil, patterns: nil, sources: nil, tags: Set.new(), before_examples: [], after_examples: [], justifications: [])
+    r1 = Rule.new(id: "ruby.pathname", messages: nil, patterns: nil, sources: nil, tags: Set.new(), before_examples: [], after_examples: [], justifications: [], examples: [])
+    r2 = Rule.new(id: "minitest.assert", messages: nil, patterns: nil, sources: nil, tags: Set.new(), before_examples: [], after_examples: [], justifications: [], examples: [])
     all_rules = Set.new([r1, r2])
 
     assert_equal Set.new([r1, r2]), Check::Query.new(:append, nil, "ruby").apply(current: Set.new([r2]), all: all_rules)

--- a/test/data/test1/querly.yml
+++ b/test/data/test1/querly.yml
@@ -9,3 +9,6 @@ rules:
     justification:
       - Some reason
       - Another reason
+    examples:
+      - before: foobar
+        after: foobarbaz

--- a/test/smoke_test.rb
+++ b/test/smoke_test.rb
@@ -70,7 +70,8 @@ class SmokeTest < Minitest::Test
                              rule: {
                                id: "test1.rule1",
                                messages: ["Use foo.bar instead of foobar\n\nfoo.bar is not good.\n"],
-                               justifications: ["Some reason", "Another reason"]
+                               justifications: ["Some reason", "Another reason"],
+                               examples: [{ before: "foobar", after: "foobarbaz" }],
                              }
                            }
                          ],
@@ -113,17 +114,17 @@ class SmokeTest < Minitest::Test
                            {
                              script: "script.rb",
                              location: { start: [1, 0], end: [1, 4] },
-                             rule: { id: "test.pppp", messages: :_, justifications: :_ }
+                             rule: { id: "test.pppp", messages: :_, justifications: :_, examples: :_ }
                            },
                            {
                              script: "script.rb",
                              location: { start: [2, 0], end: [2, 5] },
-                             rule: { id: "test.pppp", messages: :_, justifications: :_ }
+                             rule: { id: "test.pppp", messages: :_, justifications: :_, examples: :_ }
                            },
                            {
                              script: "script.rb",
                              location: { start: [3, 0], end: [3, 6] },
-                             rule: { id: "test.pppp", messages: :_, justifications: :_ }
+                             rule: { id: "test.pppp", messages: :_, justifications: :_, examples: :_ }
                            },
                          ],
                          errors: []


### PR DESCRIPTION
Let examples for each rule be written in more structured manner.

```yaml
rules:
  - id: foo.bar
    pattern: count !{}
    message: |
      Prefer Array#size or Array#length over Array#count
    examples:
      - before: "array.count"
        after: "array.length"
```

This allows printing better example of rewriting from `before` to `after`.