### PR TITLE
Display error message in `querly-pp haml` if HAML 5.0+ is used

### DIFF
--- a/lib/querly/pp/cli.rb
+++ b/lib/querly/pp/cli.rb
@@ -55,6 +55,14 @@ module Querly
 
       def run_haml
         require "haml"
+        if Haml::VERSION >= '5.0.0'
+          raise <<~ERROR
+            HAML 5.0+ is detected.
+            `querly-pp haml` does not work on HAML 5.0+.
+            Use `haml -d` instead.
+          ERROR
+        end
+
         load_libs
 
         source = stdin.read


### PR DESCRIPTION
Fix #15 

```
$ querly-pp haml < test.haml
/home/pocke/.gem/ruby/2.4.0/gems/querly-0.5.0/lib/querly/pp/cli.rb:59:in `run_haml': HAML 5.0+ is detected. (RuntimeError)
`querly-pp haml` does not work on HAML 5.0+.
Use `haml -d` instead.
	from /home/pocke/.gem/ruby/2.4.0/gems/querly-0.5.0/lib/querly/pp/cli.rb:48:in `run'
	from /home/pocke/.gem/ruby/2.4.0/gems/querly-0.5.0/exe/querly-pp:7:in `<top (required)>'
	from /home/pocke/.gem/ruby/2.4.0/bin/querly-pp:22:in `load'
	from /home/pocke/.gem/ruby/2.4.0/bin/querly-pp:22:in `<main>'

```