### PR TITLE
requires activesuport ~> 5.1.1 is too new

### DIFF
--- a/querly.gemspec
+++ b/querly.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor', "~> 0.19"
   spec.add_dependency "parser", "~> 2.4.0"
   spec.add_dependency "rainbow", "~> 2.1"
-  spec.add_dependency "activesupport", "~> 5.1.1"
+  spec.add_dependency "activesupport", "~> 5.0"
 end


### PR DESCRIPTION
activesupport 5.0.x seems to work well.