### PR TITLE
Load current dir by default

### DIFF
--- a/lib/querly/cli.rb
+++ b/lib/querly/cli.rb
@@ -40,7 +40,7 @@ Specify configuration file by --config option.
 
         analyzer = Analyzer.new(config: config)
 
-        ScriptEnumerator.new(paths: paths.map {|path| Pathname(path) }, config: config).each do |path, script|
+        ScriptEnumerator.new(paths: paths.empty? ? [Pathname.pwd] : paths.map {|path| Pathname(path) }, config: config).each do |path, script|
           case script
           when Script
             analyzer.scripts << script
@@ -64,7 +64,7 @@ Specify configuration file by --config option.
     desc "console [paths]", "Start console for given paths"
     def console(*paths)
       require 'querly/cli/console'
-      Console.new(paths: paths.map {|path| Pathname(path) }).start
+      Console.new(paths: paths.empty? ? [Pathname.pwd] : paths.map {|path| Pathname(path) }).start
     end
 
     desc "test", "Check configuration"

--- a/test/smoke_test.rb
+++ b/test/smoke_test.rb
@@ -48,7 +48,7 @@ class SmokeTest < Minitest::Test
   end
 
   def test_test
-    sh!("bundle", "exec", "querly", "--config=sample.yml", "test", ".")
+    sh!("bundle", "exec", "querly", "--config=sample.yml", "test")
   end
 
   def test_console
@@ -66,6 +66,28 @@ class SmokeTest < Minitest::Test
                          issues: [
                            {
                              script: "script.rb",
+                             location: { start: [1,0], end: [1,8] },
+                             rule: {
+                               id: "test1.rule1",
+                               messages: ["Use foo.bar instead of foobar\n\nfoo.bar is not good.\n"],
+                               justifications: ["Some reason", "Another reason"],
+                               examples: [{ before: "foobar", after: "foobarbaz" }],
+                             }
+                           }
+                         ],
+                         errors: []
+                       }, output)
+    end
+  end
+
+  def test_check_when_omit_paths
+    test_dir = root + "test/data/test1"
+    push_dir test_dir do
+      output = JSON.parse(sh!("bundle", "exec", "querly", "check", "--format=json"), symbolize_names: true)
+      assert_unifiable({
+                         issues: [
+                           {
+                             script: (test_dir + "script.rb").cleanpath.to_s,
                              location: { start: [1,0], end: [1,8] },
                              rule: {
                                id: "test1.rule1",


### PR DESCRIPTION
Currently, Querly loads only the paths received by arguments. If I do not pass paths, It will not load anything. This behavior makes me confused.

```
$ querly check
# Querly does not print anything and returns "0" as exit status.
# It looks like there is no problem in my source code!
```
I think that as with many other linters (e.g. RuboCop, Reek), Querly loads the current directory by default.