### PR TITLE
Raise LoadError when receiving a file name that does not exist

### DIFF
--- a/lib/querly/script_enumerator.rb
+++ b/lib/querly/script_enumerator.rb
@@ -11,11 +11,10 @@ module Querly
     def each(&block)
       if block_given?
         paths.each do |path|
-          case
-          when path.file?
-            load_script_from_path path, &block
-          when path.directory?
+          if path.directory?
             enumerate_files_in_dir(path, &block)
+          else
+            load_script_from_path path, &block
           end
         end
       else

--- a/test/smoke_test.rb
+++ b/test/smoke_test.rb
@@ -153,4 +153,17 @@ class SmokeTest < Minitest::Test
                        }, JSON.parse(out, symbolize_names: true))
     end
   end
+
+  def test_load_file_not_found
+    push_dir root + "test/data/test3" do
+      out, _, status = sh("bundle", "exec", "querly", "check", "--format=json", "not_found.rb")
+
+      assert status.success?
+      assert_unifiable({
+                         issues: [],
+                         errors: [{ path: "not_found.rb", error: :_ }]
+                       }, JSON.parse(out, symbolize_names: true))
+    end
+  end
+
 end


### PR DESCRIPTION
Querly does not raise the exception if receiving a file name that does not exist. However, in this case, I would like to display that the file does not exist.