### PR TITLE
Make Any pattern not to match `nil`

### DIFF
--- a/lib/querly/pattern/expr.rb
+++ b/lib/querly/pattern/expr.rb
@@ -23,7 +23,7 @@ module Querly
 
       class Any < Base
         def test_node(node)
-          true
+          !!node
         end
       end
 

--- a/lib/querly/pattern/parser.y
+++ b/lib/querly/pattern/parser.y
@@ -66,10 +66,10 @@ keyword: LIDENT | UIDENT
 constant: UIDENT { result = [val[0]] }
   | UIDENT COLONCOLON constant { result = [val[0]] + val[2] }
 
-send: LIDENT block { result = val[1] != nil ? Expr::Send.new(receiver: Expr::Any.new, name: val[0], args: Argument::AnySeq.new, block: val[1]) : Expr::Vcall.new(name: val[0]) }
-  | UIDENT block { result = Expr::Send.new(receiver: Expr::Any.new, name: val[0], block: val[1]) }
-  | method_name { result = Expr::Send.new(receiver: Expr::Any.new, name: val[0], block: nil) }
-  | method_name_or_ident LPAREN args RPAREN block { result = Expr::Send.new(receiver: Expr::Any.new,
+send: LIDENT block { result = val[1] != nil ? Expr::Send.new(receiver: nil, name: val[0], args: Argument::AnySeq.new, block: val[1]) : Expr::Vcall.new(name: val[0]) }
+  | UIDENT block { result = Expr::Send.new(receiver: nil, name: val[0], block: val[1]) }
+  | method_name { result = Expr::Send.new(receiver: nil, name: val[0], block: nil) }
+  | method_name_or_ident LPAREN args RPAREN block { result = Expr::Send.new(receiver: nil,
                                                                             name: val[0],
                                                                             args: val[2],
                                                                             block: val[4]) }

--- a/test/pattern_parser_test.rb
+++ b/test/pattern_parser_test.rb
@@ -41,7 +41,7 @@ class PatternParserTest < Minitest::Test
 
   def test_keyword_arg
     pat = parse_expr("foo(!x: 1, ...)")
-    assert_equal E::Send.new(receiver: E::Any.new,
+    assert_equal E::Send.new(receiver: nil,
                              name: :foo,
                              args: A::KeyValue.new(key: :x,
                                                    value: E::Literal.new(type: :int, value: 1),
@@ -52,7 +52,7 @@ class PatternParserTest < Minitest::Test
 
   def test_keyword_arg2
     pat = parse_expr("foo(!X: 1, ...)")
-    assert_equal E::Send.new(receiver: E::Any.new,
+    assert_equal E::Send.new(receiver: nil,
                              name: :foo,
                              args: A::KeyValue.new(key: :X,
                                                    value: E::Literal.new(type: :int, value: 1),
@@ -63,7 +63,7 @@ class PatternParserTest < Minitest::Test
 
   def test_send_with_block
     pat = parse_expr("foo() {}")
-    assert_equal E::Send.new(receiver: E::Any.new,
+    assert_equal E::Send.new(receiver: nil,
                              name: :foo,
                              args: nil,
                              block: true), pat
@@ -71,7 +71,7 @@ class PatternParserTest < Minitest::Test
 
   def test_send_without_block
     pat = parse_expr("foo() !{}")
-    assert_equal E::Send.new(receiver: E::Any.new,
+    assert_equal E::Send.new(receiver: nil,
                              name: :foo,
                              args: nil,
                              block: false), pat
@@ -79,7 +79,7 @@ class PatternParserTest < Minitest::Test
 
   def test_send_without_block2
     pat = parse_expr("foo !{}")
-    assert_equal E::Send.new(receiver: E::Any.new,
+    assert_equal E::Send.new(receiver: nil,
                              name: :foo,
                              args: A::AnySeq.new,
                              block: false), pat
@@ -87,7 +87,7 @@ class PatternParserTest < Minitest::Test
 
   def test_send_with_block_uident
     pat = parse_expr("Foo {}")
-    assert_equal E::Send.new(receiver: E::Any.new,
+    assert_equal E::Send.new(receiver: nil,
                              name: :Foo,
                              args: A::AnySeq.new,
                              block: true), pat

--- a/test/pattern_test_test.rb
+++ b/test/pattern_test_test.rb
@@ -183,10 +183,21 @@ class PatternTestTest < Minitest::Test
 
   def test_call_with_names
     node = E::Send.new(name: [:foo, :bar, /baz/], args: nil, receiver: E::Any.new, block: nil)
-    assert node.test_node(ruby("foo()"))
-    assert node.test_node(ruby("bar()"))
-    assert node.test_node(ruby("foo_bar_baz()"))
-    refute node.test_node(ruby("test()"))
+    assert node.test_node(ruby("a.foo()"))
+    assert node.test_node(ruby("a.bar()"))
+    assert node.test_node(ruby("a.foo_bar_baz()"))
+    refute node.test_node(ruby("a.test()"))
+  end
+
+  def test_call_without_receiver
+    nodes = query_pattern("foo", "foo; bar.foo")
+    assert_equal 2, nodes.size
+  end
+
+  def test_call_with_any_receiver
+    nodes = query_pattern("_.foo", "foo; bar.foo")
+    assert_equal 1, nodes.size
+    assert_equal ruby("bar.foo"), nodes.first
   end
 
   def test_vcall


### PR DESCRIPTION
Problem
====

Currently, Any pattern matches `nil`.
Therefore, `_.foo` matches `foo`(without receiver). I think this behaviour is confusing. The pattern should match a send node **with receiver**.

For example:

`querly.yaml`

```yaml
rules:
  - id: test
    pattern: '_.belongs_to(:symbol:, ..., !index: _, ...)'
    message: '`belongs_to` adds an index always in Rails 5. If you do not need it, add `index: false`.'
    examples:
      - before: 't.belongs_to :user'
        after:  't.belongs_to :user, index: false'
      # `belongs_to` is called under app/models/ also, but it's correct.
      - after:  'belongs_to :user'
```

`querly test` for the rule definition is failed.
Because the rule matches `belongs_to :user`.

```bash
$ querly test
warning: parser/current is loading parser/ruby24, which recognizes
warning: 2.4.0-compliant syntax, but you are running 2.4.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
/home/pocke/.gem/ruby/2.4.0/gems/parser-2.4.0.0/lib/parser/lexer.rb:10922: warning: assigned but unused variable - testEof
/home/pocke/.gem/ruby/2.4.0/gems/querly-0.6.0/lib/querly/node_pair.rb:28: warning: `&' interpreted as argument prefix
/home/pocke/.gem/ruby/2.4.0/gems/querly-0.6.0/lib/querly/pattern/parser.rb:793: warning: mismatched indentations at 'end' with 'module' at 9
/home/pocke/.gem/ruby/2.4.0/gems/querly-0.6.0/lib/querly/pattern/parser.rb:794: warning: mismatched indentations at 'end' with 'module' at 8
Checking rule id uniqueness...
Checking rule patterns...
  test:	after of 2nd example matched with some of patterns
Tested 1 rules with 3 tests.
  1 examples found which should not match, but matched
  0 examples found which should match, but didn't
  0 examples raised error
```

Solution
====

- `Any` pattern matches only if node exists.
- Do not use `Any`pattern when receiver is omitted.