### PR TITLE
RIP Wiki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* Add Wiki pages to repository in manual directory #25
+
 ## 0.6.0 (2017-06-27)
 
 * Load current directory when no path is given (@wata727) #18

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -1,0 +1,94 @@
+# Overview
+
+The configuration file, default name is `querly.yml`, will look like the following.
+
+```yml
+rules:
+  ...
+preprocessor:
+  ...
+check:
+  ...
+```
+
+# rules
+
+`rules` is array of rule hash.
+
+```yml
+  - id: com.sideci.json
+    pattern: Net::HTTP
+    message: "Should use HTTPClient instead of Net::HTTP"
+    justification:
+      - No exception!
+    before:
+      - "Net::HTTP.get(url)"
+    after:
+      - HTTPClient.new.get_content(url)
+```
+
+The rule hash contains following keys:
+
+* `id` Identifier of the rule, must be unique (string)
+* `pattern` Patterns to find out (string, or array of string)
+* `message` Error message to explain why the code fragment needs special care (string)
+* `justification` When the *bad use* is allowed (string, or array of string)
+* `before` Sample ruby code to find out (string, or array of string)
+* `after` Sample ruby code to be fixed (string, or array of string)
+
+# preprocessor
+
+When your project contains `.slim`, `.haml`, or any templates which contains Ruby code, preprocessor is to translate the templates to Ruby code.
+`preprocessor` is a hash; key of extension of the templates, value of command line.
+
+```yml
+.slim: slimrb --compile
+.haml: bundle exec querly-pp haml -I lib -r your_custom_plugin
+```
+
+The command will be executed with stdin of template code, and should emit ruby code to stdout.
+
+## querly-pp
+
+Querly 0.2.0 ships with `querly-pp` command line tool which compiles given HAML source to Ruby script.
+`-I` and `-r` options can be used to use plugins.
+
+# check
+
+Define set of rules to check for each file.
+
+```yml
+check:
+  - path: /test
+    rules:
+      - com.acme.corp
+      - append: com.acme.corp
+      - except: com.acme.corp
+      - only: com.acme.corp
+  - path: /test/unit
+    rules:
+      - append:
+          tags: foo bar
+      - except:
+          tags: foo bar
+      - only:
+          tags: foo bar
+```
+
+* `path` Files to apply the rules in `.gitignore` syntax
+* `rules` Rules to check
+
+All matching `check` element against given file name will be applied, sequentially.
+
+* `/lib/bar.rb` => no checks will be applied (all rules)
+* `/test/test_helper.rb` => `/test` check will be applied
+* `/test/unit/account_test.rb` => `/test` and `/test/unit` checks will be applied
+
+## Rules
+
+You can use `append:`, `except:` and `only:` operation.
+
+* `append:` appends rules to current rule set
+* `except:` removes rules from current rule set
+* `only:` update current rule set
+

--- a/manual/examples.md
+++ b/manual/examples.md
@@ -1,0 +1,35 @@
+In this page, I will show some rules I have written. They are all real rules from my repos.
+
+# `js: true` option with feature spec
+
+I see some of Feature Spec scenarios have `js: true` option, and others do not. The reason they look strange to me is some scenarios without `js: true` depend on JavaScript. I changed one of the `js: true` to `js: false`, and run the specs again. They run! What is happening?? The `js` does not stand for *JavaScript*?? What else?
+
+The magic happens in `rails_helper.rb`.
+
+```rb
+Capybara.configure do |config|
+  config.default_driver    = :poltergeist
+  config.javascript_driver = :poltergeist
+end
+```
+
+Okay, `js: true` does not make any sense, because both `default_driver` and `javascript_driver` are same.
+
+Should we fix all of the scenarios now? If we leave them, new teammates will misunderstand `js: true` does something important and required. However, we don't want to fix them now. It does not do anything bad right now. So, my conclusion is *I will do that, but not now* 😸 
+
+It's the time to add a new Querly rule. When someone tries to add new scenario with `js: true`, tell the person that it does not make any sense.
+
+```yaml
+- id: sample.scenario_with_js_option
+  pattern: "scenario(..., js: _, ...)"
+  message: |
+    You do not need js:true option
+
+    We are using Poltergeist as both default_driver and javascript_driver!
+  before:
+    - "scenario 'hello world', js: true, type: :feature do end"
+  after:
+    - "scenario 'foo bar' do end"
+```
+
+No new `js: true` scenario will be written. Our new teammate may try to write that. But Querly will tell they don't have to do that, instead of me.

--- a/manual/patterns.md
+++ b/manual/patterns.md
@@ -1,0 +1,168 @@
+# Syntax
+
+## Toplevel
+
+* *expr*
+* *expr* `[` *kind* `]` (kinded expr)
+* *expr* `[!` *kind* `]` (negated kinded expr)
+
+## expr
+
+* `_` (any expr)
+* *method* (method call, with any receiver and any args)
+* *method* `(` *args* `)` *block_spec* (method call with any receiver)
+* *receiver* *method* (method call with any args)
+* *receiver* *method* `(` *args* `)` *block_spec* (method call)
+* *literal*
+* `self` (self)
+* `!` *expr*
+
+### block_spec
+
+* (no spec)
+* `{}` (method call should be with block)
+* `!{}` (method call should not be with block)
+
+### receiver
+
+* *expr* `.` (receiver matching with the pattern)
+* *expr* `...` (some receiver in the chain matching with the pattern)
+
+### Examples
+
+* `p(_)` `p` call with one argument, any receiver
+* `self.p(1)` `p` call with `1`, receiver is `self` or omitted.
+* `foo.bar.baz` `baz` call with receiver of `bar` call of receiver of `foo` call
+* `update_attribute(:symbol:, :string:)` `update_attribute` call with symbol and string literals
+* `File.open(...) !{}` `File.open` call but without block
+
+```rb
+p 1        # p(_) matches
+p 2        # p(_) matches
+p 1, 2, 3  # p(_) does not match
+
+p(1)       # self.p(1) matches
+
+foo(1).bar {|x| x+1 }.baz(3)  # foo.bar.baz matches
+(1+2).foo.bar(*args).baz.bla  # foo.bar.baz matches, partially
+foo.xyz.bar.baz               # foo.bar.baz does not match
+
+update_attribute(:name, "hoge")    # f(:symbol:, :string:) matches
+update_attribute(:name, name)      # f(:symbol:, :string:) does not match
+
+foo.bar.baz               # foo.bar.baz matches
+foo.bar.baz               # foo...baz matches
+bar.foo.baz               # foo...bar...baz does not match
+```
+
+## args & kwargs
+
+### args
+
+* *expr* `,` *args*
+* *expr* `,` *kwargs*
+* *expr*
+* `...` `,` *kwargs* (any argument sequence, followed by keyword arguments)
+* `...` (any argument sequence, including any keyword arguments)
+
+### Literals
+
+* `123` (integer)
+* `1.23` (float)
+* `:foobar` (symbol)
+* `:symbol:` (any symbol literal)
+* `:string:` (any string literal)
+* `:dstr:` (any dstr `"hi #{name}"`)
+* `true`, `false` (true and false)
+* `nil` (nil)
+* `:number:`, `:int:`, `:float:` (any number, any integer, any float)
+* `:bool:` (true or false)
+
+### kwargs
+
+* *symbol* `:` *expr* `,` ...
+* `!` *symbol* `:` *expr* `,` ...
+* `...`
+* `&` *expr*
+
+### Examples
+
+```rb
+f(1,2,3)   # f(...), f(1,2,...), and f(1, ...) matches
+           # f(_,_), f(0, ...) does not match
+
+JSON.load(string, symbolize_names: true)   # JSON.load(..., symbolize_names: true) matches
+                                           # JSON.load(symbolize_names: true) does not match
+
+record.update(email: email, name: name)    # update(name: _, email: _) matches
+                                           # update(name: _) does not match
+                                           # update(name: _, ...) matches
+                                           # update(!id: _, ...) matches
+
+article.try(&:author)        # try(&:symbol:) matches
+article.try(:author)         # try(&:symbol:) does not match
+article.try {|x| x.author }  # try(&:symbol:) does not match
+```
+
+## kind
+
+* `conditional` (When expr appears in *conditional* context)
+* `discarded` (When expr appears in *discarded* context)
+
+Kind allows you to find out something like:
+
+* `save` call but does not check its result for error recovery
+
+*conditional* context is
+
+* Condition of `if` construct
+* Condition of loop constructs
+* LHS of `&&` and `||`
+
+```rb
+# record.save is in conditional context
+unless record.save
+  # error recovery
+end
+
+# record.save is not in conditional context
+x = record.save
+
+# record.save is in conditional context
+record.save or abort()
+```
+
+*discarded* context is where the value of the expression is completely discarded, a bit looser than *conditional*.
+
+```rb
+def f()
+  # record.save is in discarded context
+  foo()
+  record.save()
+  bar
+end
+```
+
+# Difference from Ruby
+
+* Method call parenthesis cannot be omitted (if omitted, it means *any arguments*)
+* `+`, `-`, `[]` or other *operator* should be written as method calls like `_.+(_)`, `[]=(:string:, _)`
+
+# Testing
+
+You can test patterns by `querly console .` command interactively.
+
+```
+Querly 0.1.0, interactive console
+
+Commands:
+  - find PATTERN   Find PATTERN from given paths
+  - reload!        Reload program from paths
+  - quit
+
+Loading... ready!
+> 
+```
+
+Also `querly test` will help you.
+It test configuration file by checking patterns in rules against `before` and `after` examples.


### PR DESCRIPTION
Querly stops using Wiki and put the contents in `manual` directory.