### PR TITLE
Parsing assert

### DIFF
--- a/lib/querly/pattern/parser.y
+++ b/lib/querly/pattern/parser.y
@@ -127,9 +127,9 @@ def next_token
   case
   when input.eos?
     [false, false]
-  when input.scan(/true/)
+  when input.scan(/true\b/)
     [:BOOL, true]
-  when input.scan(/false/)
+  when input.scan(/false\b/)
     [:BOOL, false]
   when input.scan(/nil/)
     [:NIL, false]
@@ -152,7 +152,7 @@ def next_token
   when input.scan(/:\w+/)
     s = input.matched
     [:SYMBOL, s[1, s.size - 1].to_sym]
-  when input.scan(/as/)
+  when input.scan(/as\b/)
     [:AS, :as]
   when input.scan(/{}/)
     [:WITH_BLOCK, nil]

--- a/test/pattern_parser_test.rb
+++ b/test/pattern_parser_test.rb
@@ -212,4 +212,18 @@ class PatternParserTest < Minitest::Test
     assert_equal :string, pat.type
     assert_equal ["foo"], pat.values
   end
+
+  def test_as_something
+    pat = parse_expr("assert()")
+    assert_instance_of E::Send, pat
+    assert_equal [:assert], pat.name
+  end
+
+  def test_as_things2
+    %w(assert true_or_false falsey).each do |word|
+      pat = parse_expr("#{word}()")
+      assert_instance_of E::Send, pat
+      assert_equal [word.to_sym], pat.name
+    end
+  end
 end


### PR DESCRIPTION
Fix parsing failure on `assert` since it is tokenized as `as` + `sert`.