### PR TITLE
Make `[conditional]` kind aware of safe navigation operator

### DIFF
--- a/lib/querly/pattern/kind.rb
+++ b/lib/querly/pattern/kind.rb
@@ -44,6 +44,8 @@ module Querly
             node.equal? parent.children.first
           when :or
             node.equal? parent.children.first
+          when :csend
+            node.equal? parent.children.first
           else
             false
           end

--- a/test/pattern_test_test.rb
+++ b/test/pattern_test_test.rb
@@ -310,4 +310,34 @@ class PatternTestTest < Minitest::Test
     nodes = query_pattern("has_many(:symbol: as 'children)", "has_many(:children); has_many(:repositories)", where: { children: [:children] })
     assert_equal Set.new([ruby("has_many :children")]), Set.new(nodes)
   end
+
+  def test_conditional_if
+    nodes = query_pattern('foo [conditional]', 'if foo; foo; end')
+    assert_equal 1, nodes.size
+    assert_equal ruby('foo'), nodes.first
+  end
+
+  def test_conditional_while
+    nodes = query_pattern('foo [conditional]', 'while foo; foo; end')
+    assert_equal 1, nodes.size
+    assert_equal ruby('foo'), nodes.first
+  end
+
+  def test_conditional_and
+    nodes = query_pattern('foo [conditional]', 'foo && bar')
+    assert_equal 1, nodes.size
+    assert_equal ruby('foo'), nodes.first
+  end
+
+  def test_conditional_or
+    nodes = query_pattern('foo [conditional]', 'foo || bar')
+    assert_equal 1, nodes.size
+    assert_equal ruby('foo'), nodes.first
+  end
+
+  def test_conditional_csend
+    nodes = query_pattern('foo [conditional]', 'foo&.bar')
+    assert_equal 1, nodes.size
+    assert_equal ruby('foo'), nodes.first
+  end
 end


### PR DESCRIPTION
Receiver of safe navigation operator should be marked as conditional, but querly does not mark it.
For example:

We have a rule for `find_by`.

```yaml
rules:
  - id: com.sideci.find_with_bang
    pattern: "find_by(_) [!conditional]"
    message: find_by returns a nil if the specified record does not exist. Use find_by! instead.
```

```ruby
User.find_by(email: email)&.full_name
```

The `find_by` is in a conditional. So querly should not warn for the code, but querly warns. Because querly does not treat safe navigation operators as a conditional.


This change will fix this problem.


Note: I can't find any tests for conditional kinds. So I added tests for them.