### PR TITLE
Fix preprocessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* Fix preprocessor to avoid deadlocking #35
+
 ## 0.8.2 (2018-01-13)
 
 * Move `Concerns::BacktraceFormatter` under `Querly`  (@kohtaro24) #34

--- a/lib/querly/preprocessor.rb
+++ b/lib/querly/preprocessor.rb
@@ -18,14 +18,8 @@ module Querly
       @command = command
     end
 
-    def run!(source_code)
-      stdin_read, stdin_write = IO.pipe
+    def run!(path)
       stdout_read, stdout_write = IO.pipe
-
-      writer = Thread.new do
-        stdin_write.print source_code
-        stdin_write.close
-      end
 
       output = ""
 
@@ -35,10 +29,9 @@ module Querly
         end
       end
 
-      succeeded = system(command, in: stdin_read, out: stdout_write)
+      succeeded = system(command, in: path.to_s, out: stdout_write)
       stdout_write.close
 
-      writer.join
       reader.join
 
       raise Error.new(status: $?, command: command) unless succeeded

--- a/lib/querly/script_enumerator.rb
+++ b/lib/querly/script_enumerator.rb
@@ -40,7 +40,7 @@ module Querly
 
       begin
         source = if preprocessor
-                   preprocessor.run!(path.read)
+                   preprocessor.run!(path)
                  else
                    path.read
                  end

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -3,13 +3,23 @@ require_relative "test_helper"
 class PreprocessorTest < Minitest::Test
   Preprocessor = Querly::Preprocessor
 
+  def with_temp_file(content)
+    Tempfile.create("querly-preprocessor") do |io|
+      io.write content
+      io.close
+      yield Pathname(io.path)
+    end
+  end
+
   def test_preprocessing_succeeded
     preprocessor = Preprocessor.new(ext: ".foo", command: "cat -n")
 
-    target = preprocessor.run!(<<-EOS)
+    target = with_temp_file(<<-EOS) do |path|
 foo
 bar
     EOS
+      preprocessor.run!(path)
+    end
 
     assert_equal(<<-EXPECTED, target)
      1\tfoo
@@ -21,10 +31,12 @@ bar
     preprocessor = Preprocessor.new(ext: ".foo", command: "grep XYZ")
 
     assert_raises Preprocessor::Error do
-      preprocessor.run!(<<-EOS)
+      with_temp_file(<<-EOS) do |path|
 foo
 bar
-      EOS
+    EOS
+        preprocessor.run!(path)
+      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require "querly/cli/test"
 require 'minitest/autorun'
 require "tmpdir"
 require "unification_assertion"
+require "tempfile"
 
 Rainbow.enabled = false
 


### PR DESCRIPTION
To handle input correctly, without deadlocking, pass the path to the input, instead of a pipe.