### PR TITLE
Loosen the restriction of `thor` version

### DIFF
--- a/querly.gemspec
+++ b/querly.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "racc", "= 1.4.14"
   spec.add_development_dependency "unification_assertion", "0.0.1"
 
-  spec.add_dependency 'thor', "~> 0.20"
+  spec.add_dependency 'thor', ">= 0.19.0", "< 0.21.0"
   spec.add_dependency "parser", "~> 2.4.0"
   spec.add_dependency "rainbow", "~> 3.0"
   spec.add_dependency "activesupport", "~> 5.0"


### PR DESCRIPTION
This patch allows `querly` gem to be used not only with [`thor`](https://github.com/erikhuda/thor) v0.20.0 but with v0.19.0.

Here is the reason:

1. [`foreman`](https://github.com/ddollar/foreman), a CLI tool most [Heroku](https://heroku.com)-based apps depends on, still uses `thor` v0.19.0.
2. When I try to install the latest `querly` along with `foreman` in the same project, I should use [the extremely older version of `foreman`](https://github.com/ddollar/foreman/releases/tag/v0.64.0) [that can be used with `thor` v0.20.0](https://github.com/ddollar/foreman/blob/v0.64.0/foreman.gemspec#L20). 
3. Though I submitted [a pull request to update `foreman` to switch `thor` to v0.20.0](https://github.com/ddollar/foreman/pull/701), I guess the project author won't merge it soon as far as I see his recent activity on Github.

------

We can revert this change when https://github.com/ddollar/foreman/pull/701 is merged in the future.
