### PR TITLE
Fix a bug. Regexp literal matches all literal patterns.

### DIFF
--- a/lib/querly/pattern/expr.rb
+++ b/lib/querly/pattern/expr.rb
@@ -125,7 +125,7 @@ module Querly
             test_value(node.children.first)
 
           when :regexp
-            type == :regexp
+            return false unless type == :regexp
             test_value(node.children.first)
 
           end

--- a/test/pattern_test_test.rb
+++ b/test/pattern_test_test.rb
@@ -49,6 +49,24 @@ class PatternTestTest < Minitest::Test
     end
   end
 
+  def test_int
+    nodes = query_pattern(":int:", "[/1/, 1, 3.0, 1i, 1r]")
+    assert_equal 1, nodes.size
+    assert_equal [ruby("1")], nodes
+  end
+
+  def test_float
+    nodes = query_pattern(":float:", "['42', /1/, 1, 3.0, 1i, 1r]")
+    assert_equal 1, nodes.size
+    assert_equal [ruby("3.0")], nodes
+  end
+
+  def test_bool
+    nodes = query_pattern(":bool:", "[true, false, nil]")
+    assert_equal 2, nodes.size
+    assert_equal [ruby("true"), ruby('false')], nodes
+  end
+
   def test_symbol
     nodes = query_pattern(":symbol:", ":foo")
     assert_node nodes.first, type: :sym do |name, *_|
@@ -81,6 +99,12 @@ class PatternTestTest < Minitest::Test
     nodes = E::Literal.new(type: :string, values: [/foo/])
     assert nodes.test_node(ruby('"foo bar"'))
     refute nodes.test_node(ruby('"baz"'))
+  end
+
+  def test_regexp
+    nodes = query_pattern(":regexp:", '[/1/, /#{2}/, 3]')
+    assert_equal 2, nodes.size
+    assert_equal [ruby("/1/"), ruby('/#{2}/')], nodes
   end
 
   def test_call_without_args
@@ -268,12 +292,6 @@ class PatternTestTest < Minitest::Test
     nodes = query_pattern("foo() !{}", "foo do foo() end")
     assert_equal 1, nodes.size
     assert_equal ruby("foo()"), nodes.first
-  end
-
-  def test_regexp
-    nodes = query_pattern(":regexp:", "[/1/, /#{2}/, 3]")
-    assert_equal 2, nodes.size
-    assert_equal [ruby("/1/"), ruby("/#{2}/")], nodes
   end
 
   def test_any_receiver1


### PR DESCRIPTION
Problem
===

Regexp literal matches all literal patterns.

```bash
$ cat test.rb
/a/

$ querly console .
> find :int:
  test.rb:1:0   /a/
1 results
> find :symbol:
  test.rb:1:0   /a/
1 results
>
```

The cause
===

When `regexp` node, `test_node` method checks nothing.

https://github.com/soutaro/querly/blob/master/lib/querly/pattern/expr.rb#L127-L131

So it always returns `true`.

Solution
====

Check the type of pattern in the `test_node` method.

Note
===

I added missing test cases for other literal patterns (int, float and
bool), and I moved `test_regexp` under the test cases for literal pattern.
And I tweak the `test_regexp` test.

```
  def test_regexp
-   nodes = query_pattern(":regexp:", "[/1/, /#{2}/, 3]")
+   nodes = query_pattern(":regexp:", '[/1/, /#{2}/, 3]')
    assert_equal 2, nodes.size
-   assert_equal [ruby("/1/"), ruby("/#{2}/")], nodes
+   assert_equal [ruby("/1/"), ruby('/#{2}/')], nodes
  end
```

Currently `"[/1/, /#{2}/, 3]"` is evaluated as `"[/1/, /2/, 3]"`, so the test checks just `/1/`, `/2/` and 3.
I guess the test should check `/#{2}/`, so I replace the double quotes with single quotes.