### PR TITLE
Update parser to 2.5

### DIFF
--- a/querly.gemspec
+++ b/querly.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "unification_assertion", "0.0.1"
 
   spec.add_dependency 'thor', ">= 0.19.0", "< 0.21.0"
-  spec.add_dependency "parser", "~> 2.4.0"
+  spec.add_dependency "parser", "~> 2.5.0"
   spec.add_dependency "rainbow", "~> 3.0"
   spec.add_dependency "activesupport", "~> 5.0"
 end


### PR DESCRIPTION
﻿I tried to use querly but unfortunately I could not install it due to version conflicts of parser with Rubocop. [Rubocop](https://rubygems.org/gems/rubocop), from version 0.53.0, depends on the parser version 2.5. For example, a version conflict error occurs with the following Gemfile:

```ruby
# frozen_string_literal: true

source "https://rubygems.org"

git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }

gem "querly"
gem "rubocop", "~> 0.53.0"
```

Error:

```bash
$ bundle install
Fetching gem metadata from https://rubygems.org/...............
Resolving dependencies...
Bundler could not find compatible versions for gem "parser":
  In snapshot (Gemfile.lock):
    parser (= 2.4.0.2)

  In Gemfile:
    querly was resolved to 0.9.0, which depends on
      parser (~> 2.4.0)

    rubocop (~> 0.53.0) was resolved to 0.53.0, which depends on
      parser (>= 2.5)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

To solve this problem, I propose to fix the gemspec file. I hope you will consider this.