### PR TITLE
Fix typo intemplate.yml

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -28,7 +28,7 @@ rules:
   - id: sample.exception
     pattern: Exception
     message: |
-      You probablly should use StandardError
+      You probably should use StandardError
 
       If you are trying to define error class, inherit that from StandardError.
     justification:


### PR DESCRIPTION
Follow up of #39.

I picked up a typical typos using misspell and applied it.
https://github.com/client9/misspell

```console
% misspell -w .
template.yml:31:10: corrected "probablly" to "probably"
```