### PR TITLE
`exit 1` when `querly.yaml` has syntax error

### DIFF
--- a/lib/querly/cli.rb
+++ b/lib/querly/cli.rb
@@ -36,7 +36,7 @@ Specify configuration file by --config option.
           Config.load(yaml, config_path: config_path, root_dir: root_path, stderr: STDERR)
         rescue => exn
           formatter.config_error config_path, exn
-          exit
+          exit 1
         end
 
         analyzer = Analyzer.new(config: config, rule: options[:rule])


### PR DESCRIPTION
Querly exits with 0 currently when `querly.yaml` has syntax error.
For example:

```bash
$ cat querly.yaml
:

$ querly check
Failed to load configuration: querly.yaml
(<unknown>): did not find expected key while parsing a block mapping at line 1 column 1
Backtrace:
  /home/pocke/.rbenv/versions/trunk/lib/ruby/2.6.0/psych.rb:402:in `parse'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/2.6.0/psych.rb:402:in `parse_stream'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/2.6.0/psych.rb:350:in `parse'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/2.6.0/psych.rb:263:in `load'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/lib/querly/cli.rb:35:in `check'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/exe/querly:8:in `<top (required)>'
  /home/pocke/.rbenv/versions/trunk/bin/querly:23:in `load'
  /home/pocke/.rbenv/versions/trunk/bin/querly:23:in `<main>'

$ echo $?
0
```

I think this case is not success, it should be failure. So the exit code should be non-zero.