### PR TITLE
Highlight matched expression in querly console

### DIFF
--- a/lib/querly/cli/console.rb
+++ b/lib/querly/cli/console.rb
@@ -69,21 +69,16 @@ Querly #{VERSION}, interactive console
               analyzer.find(pattern) do |script, pair|
                 path = script.path.to_s
                 line = pair.node.loc.first_line
+                range = pair.node.loc.expression
+                start_col = range.column
+                end_col = range.last_column
 
-                while true
-                  parent = pair.parent
+                src = range.source_buffer.source_lines[line-1]
+                src = Rainbow(src[0...start_col]).blue +
+                  Rainbow(src[start_col...end_col]).bright.blue.bold +
+                  Rainbow(src[end_col..-1]).blue
 
-                  if parent && parent.node.loc.first_line == line
-                    pair = pair.parent
-                  else
-                    break
-                  end
-                end
-
-                src = Rainbow(pair.node.loc.expression.source.split(/\n/).first).blue
-                col = pair.node.loc.column
-
-                puts "  #{path}:#{line}:#{col}\t#{src}"
+                puts "  #{path}:#{line}:#{start_col}\t#{src}"
 
                 count += 1
               end


### PR DESCRIPTION
Querly console will highlight matched expression by this change.
I think the highlighting is helpful to check the output.



## before

![180521231101](https://user-images.githubusercontent.com/4361134/40311921-44e4f37c-5d4c-11e8-8e73-f391d286a7c9.png)

## after

![180521231036](https://user-images.githubusercontent.com/4361134/40311920-44b4cf62-5d4c-11e8-9f16-5bd0f4ffbc37.png)



## Note

This pull request also changes the output source code. Currently the source code is a node's. But it will be a line's by this pull request.
For example, the difference makes different outputs in the following case.

```ruby
# test.rb
foo(
  bar, baz
)
```

```
# before
> find bar
  test.rb:3:2	bar

# after
> find bar
  test.rb:3:2	  bar, baz
```

Because parent node is on the previous line in the first case, so it displays only matched node. But the second case displays whole line.

I think the new behaviour is more natural than the current behaviour to me. And I can implement the new behaviour simpler.