### PR TITLE
Print readable backtrace

### DIFF
--- a/lib/querly/cli/console.rb
+++ b/lib/querly/cli/console.rb
@@ -43,7 +43,7 @@ Querly #{VERSION}, interactive console
             @analyzer.scripts << script
           when StandardError
             p path: path, script: script.inspect
-            p script.backtrace
+            puts script.backtrace
           end
         end
 


### PR DESCRIPTION
Currently querly print an error and backtrace when parsing raises an error.
And I think the backtrace is not readable. It uses `p` method, so the backtrace shrinks to oneline.
This patch uses `puts` method instead of `p`. `puts` expands Array, so I think it is more readable.

before

```
$ querly console test.rb
Querly 0.11.0, interactive console

Commands:
  - find PATTERN   Find PATTERN from given paths
  - reload!        Reload program from paths
  - quit

Loading...{:path=>#<Pathname:test.rb>, :script=>"#<Parser::SyntaxError: unexpected token tCOLON>"}
["/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/parser-2.5.1.0/lib/parser/diagnostic/engine.rb:73:in `process'", "/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/parser-2.5.1.0/lib/parser/base.rb:262:in `on_error'", "/Users/pocke/.rbenv/versions/trunk/lib/ruby/2.6.0/racc/parser.rb:259:in `_racc_do_parse_c'", "/Users/pocke/.rbenv/versions/trunk/lib/ruby/2.6.0/racc/parser.rb:259:in `do_parse'", "/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/parser-2.5.1.0/lib/parser/base.rb:167:in `parse'", "/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/lib/querly/script_enumerator.rb:50:in `load_script_from_path'", "/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/lib/querly/script_enumerator.rb:17:in `block in each'", "/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/lib/querly/script_enumerator.rb:13:in `each'", "/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/lib/querly/script_enumerator.rb:13:in `each'", "/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/lib/querly/cli/console.rb:40:in `analyzer'", "/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/lib/querly/cli/console.rb:32:in `reload!'", "/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/lib/querly/cli/console.rb:24:in `start'", "/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/lib/querly/cli.rb:68:in `console'", "/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'", "/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'", "/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'", "/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'", "/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/exe/querly:8:in `<top (required)>'", "/Users/pocke/.rbenv/versions/trunk/bin/querly:23:in `load'", "/Users/pocke/.rbenv/versions/trunk/bin/querly:23:in `<main>'"]
 ready!
```

after

```
$ querly console test.rb
Querly 0.11.0, interactive console

Commands:
  - find PATTERN   Find PATTERN from given paths
  - reload!        Reload program from paths
  - quit

Loading...{:path=>#<Pathname:test.rb>, :script=>"#<Parser::SyntaxError: unexpected token tCOLON>"}
/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/parser-2.5.1.0/lib/parser/diagnostic/engine.rb:73:in `process'
/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/parser-2.5.1.0/lib/parser/base.rb:262:in `on_error'
/Users/pocke/.rbenv/versions/trunk/lib/ruby/2.6.0/racc/parser.rb:259:in `_racc_do_parse_c'
/Users/pocke/.rbenv/versions/trunk/lib/ruby/2.6.0/racc/parser.rb:259:in `do_parse'
/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/parser-2.5.1.0/lib/parser/base.rb:167:in `parse'
/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/lib/querly/script_enumerator.rb:50:in `load_script_from_path'
/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/lib/querly/script_enumerator.rb:17:in `block in each'
/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/lib/querly/script_enumerator.rb:13:in `each'
/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/lib/querly/script_enumerator.rb:13:in `each'
/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/lib/querly/cli/console.rb:40:in `analyzer'
/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/lib/querly/cli/console.rb:32:in `reload!'
/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/lib/querly/cli/console.rb:24:in `start'
/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/lib/querly/cli.rb:68:in `console'
/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
/Users/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.6.0/gems/querly-0.11.0/exe/querly:8:in `<top (required)>'
/Users/pocke/.rbenv/versions/trunk/bin/querly:23:in `load'
/Users/pocke/.rbenv/versions/trunk/bin/querly:23:in `<main>'
 ready!
```