### PR TITLE
persistent history for `querly console`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /lib/querly/pattern/parser.rb
 parser.output
 /Gemfile.lock
+.querly_history


### PR DESCRIPTION
Resolve https://github.com/soutaro/querly/issues/46

Note that this is just an MVP; I think `history_file` and `history_size` should be configuable.