### PR TITLE
Add subcommand `find pattern [paths]`

### DIFF
--- a/lib/querly/cli.rb
+++ b/lib/querly/cli.rb
@@ -83,6 +83,16 @@ Specify configuration file by --config option.
       ).start
     end
 
+    desc "find pattern [paths]", "Find for the pattern in given paths"
+    def find(pattern, *paths)
+      require 'querly/cli/find'
+
+      Find.new(
+        pattern: pattern,
+        paths: paths.empty? ? [Pathname.pwd] : paths.map {|path| Pathname(path) },
+      ).start
+    end
+
     desc "test", "Check configuration"
     option :config, default: "querly.yml"
     def test()

--- a/lib/querly/cli/find.rb
+++ b/lib/querly/cli/find.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Querly
+  class CLI
+    class Find
+      include Concerns::BacktraceFormatter
+
+      attr_reader :pattern_str
+      attr_reader :paths
+
+      def initialize(pattern:, paths:)
+        @pattern_str = pattern
+        @paths = paths
+      end
+
+      def start
+        count = 0
+
+        analyzer.find(pattern) do |script, pair|
+          path = script.path.to_s
+          line_no = pair.node.loc.first_line
+          range = pair.node.loc.expression
+          start_col = range.column
+          end_col = range.last_column
+
+          src = range.source_buffer.source_lines[line_no-1]
+          src = Rainbow(src[0...start_col]).blue +
+            Rainbow(src[start_col...end_col]).bright.blue.bold +
+            Rainbow(src[end_col..-1]).blue
+
+          puts "  #{path}:#{line_no}:#{start_col}\t#{src}"
+
+          count += 1
+        end
+
+        puts "#{count} results"
+      rescue => exn
+        STDOUT.puts Rainbow("Error: #{exn}").red
+        STDTOU.puts "pattern: #{pattern_str}"
+        STDOUT.puts "Backtrace:"
+        STDOUT.puts format_backtrace(exn.backtrace)
+      end
+
+      def pattern
+        Pattern::Parser.parse(pattern_str, where: {})
+      end
+
+      def analyzer
+        return @analyzer if @analyzer
+
+        @analyzer = Analyzer.new(config: nil, rule: nil)
+
+        ScriptEnumerator.new(paths: paths, config: nil).each do |path, script|
+          case script
+          when Script
+            @analyzer.scripts << script
+          when StandardError
+            p path: path, script: script.inspect
+            puts script.backtrace
+          end
+        end
+
+        @analyzer
+      end
+    end
+  end
+end


### PR DESCRIPTION
`querly find $pattern [$path...]` is usable as a smart grep tool for Ruby, even if it is really slow for now.

What do you think of it?