### PR TITLE
Allow having `...` pattern in the middle of arguments

### DIFF
--- a/lib/querly/pattern/expr.rb
+++ b/lib/querly/pattern/expr.rb
@@ -200,7 +200,8 @@ module Querly
 
           case args
           when Argument::AnySeq
-            if args.tail
+            case args.tail
+            when Argument::KeyValue
               if first_node
                 case
                 when nodes.last.type == :kwsplat
@@ -213,6 +214,10 @@ module Querly
                 end
               else
                 test_hash_args({}, args.tail)
+              end
+            when Argument::Expr
+              nodes.size.times.any? do |i|
+                test_args(nodes.drop(i), args.tail)
               end
             else
               true

--- a/lib/querly/pattern/parser.y
+++ b/lib/querly/pattern/parser.y
@@ -40,6 +40,7 @@ args:  { result = nil }
   | AMP expr { result = Argument::BlockPass.new(expr: val[1]) }
   | kw_args
   | DOTDOTDOT { result = Argument::AnySeq.new }
+  | DOTDOTDOT COMMA args { result = Argument::AnySeq.new(tail: val[2]) }
   | DOTDOTDOT COMMA kw_args { result = Argument::AnySeq.new(tail: val[2]) }
 
 kw_args: { result = nil }

--- a/test/pattern_parser_test.rb
+++ b/test/pattern_parser_test.rb
@@ -39,6 +39,15 @@ class PatternParserTest < Minitest::Test
     assert_equal E::Constant.new(path: [:E]), pat
   end
 
+  def test_dot3_args
+    pat = parse_expr("foo(..., 1, ...)")
+    assert_equal E::Send.new(receiver: nil,
+                             name: :foo,
+                             args: A::AnySeq.new(tail: A::Expr.new(expr: E::Literal.new(type: :int, values: 1),
+                                                                   tail: A::AnySeq.new)),
+                             block: nil), pat
+  end
+
   def test_keyword_arg
     pat = parse_expr("foo(!x: 1, ...)")
     assert_equal E::Send.new(receiver: nil,

--- a/test/pattern_test_test.rb
+++ b/test/pattern_test_test.rb
@@ -218,6 +218,14 @@ class PatternTestTest < Minitest::Test
     assert_equal ruby("foo(2, key: 3)"), nodes.first
   end
 
+
+  def test_call_with_two_dot3
+    nodes = query_pattern("foo(..., 1, ...)",
+                          "foo(1); foo(1, 2, 3); foo(true, false); foo(2)")
+
+    assert_equal [ruby("foo(1)"), ruby("foo(1,2,3)")], nodes
+  end
+
   def test_call_with_block_pass
     nodes = query_pattern("map(&:id)", "foo.map(&:id)")
     assert_equal 1, nodes.size


### PR DESCRIPTION
Proposed by @gfx in #52.

Currently, `...` pattern is allowed only if it does not have successive positional argument patterns. This patch allows `...` pattern anywhere positional argument pattern is allowed.

`foo(..., 1, ...)` is valid pattern now and works like the following:

```
foo(1)     # match
foo(1,2,3) # match
foo(0,1,2) # match
foo(2,3,4) # no match
```