### PR TITLE
Fix config file generated by `querly init`

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -60,10 +60,10 @@ rules:
 preprocessor:
   .slim: slimrb --compile
 
-checks:
+check:
   - path: /
     rules:
-      except: sample.test
+      - except: sample.test
   - path: /test
     rules:
-      add: sample.test
+      - append: sample.test


### PR DESCRIPTION
See https://github.com/soutaro/querly/blob/v0.14.0/manual/configuration.md#check

```yaml
check:
  - path: /test
    rules:
      - com.acme.corp
      - append: com.acme.corp
      - except: com.acme.corp
      - only: com.acme.corp
  - path: /test/unit
    rules:
      - append:
          tags: foo bar
      - except:
          tags: foo bar
      - only:
          tags: foo bar
```