### PR TITLE
Relax Active Support version

### DIFF
--- a/querly.gemspec
+++ b/querly.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor', ">= 0.19.0", "< 0.21.0"
   spec.add_dependency "parser", "~> 2.5.0"
   spec.add_dependency "rainbow", ">= 2.1"
-  spec.add_dependency "activesupport", "~> 5.0"
+  spec.add_dependency "activesupport", ">= 5.0"
 end


### PR DESCRIPTION
This allow to use `querly` with Rails 6.0 application.
I confirmed that tests pass with Active Support 6.0.beta1.