### PR TITLE
Exit the console with `exit`

### DIFF
--- a/lib/querly/cli/console.rb
+++ b/lib/querly/cli/console.rb
@@ -60,7 +60,7 @@ Querly #{VERSION}, interactive console
       def start_loop
         while line = Readline.readline("> ", true)
           case line
-          when "quit"
+          when "quit", "exit"
             exit
           when "reload!"
             STDOUT.print "reloading..."

--- a/test/cli/console_test.rb
+++ b/test/cli/console_test.rb
@@ -103,7 +103,7 @@ end
         output = read_for(read, pattern: /^> $/)
         assert_match /#{Regexp.escape "User.create!(params[:user])"}/, output
 
-        write.puts "quit"
+        write.puts "exit"
         read.gets
 
         Process.wait pid


### PR DESCRIPTION
I always type `exit` instead of `quit` 🙃 