### PR TITLE
Add erb support

### DIFF
--- a/lib/querly/pp/cli.rb
+++ b/lib/querly/pp/cli.rb
@@ -84,6 +84,7 @@ module Querly
         parser.ast.descendants(:erb).each do |erb_node|
           _, _, code_node, = *erb_node
           new_source[code_node.loc.range] = code_node.loc.source
+          new_source[code_node.loc.range.end] = ';'
         end
         stdout.puts new_source
       end

--- a/lib/querly/pp/cli.rb
+++ b/lib/querly/pp/cli.rb
@@ -42,7 +42,7 @@ module Querly
       end
 
       def run
-        available_commands = [:haml]
+        available_commands = [:haml, :erb]
 
         if available_commands.include?(command)
           send :"run_#{command}"
@@ -68,6 +68,20 @@ module Querly
           compiler.compile(parser.root)
 
           stdout.print compiler.precompiled
+        end
+      end
+
+      def run_erb
+        require 'better_html'
+        require 'better_html/parser'
+        load_libs
+        source = stdin.read
+        source_buffer = Parser::Source::Buffer.new('(erb)')
+        source_buffer.source = source
+        parser = BetterHtml::Parser.new(source_buffer, template_language: :html)
+        parser.ast.descendants(:erb).each do |erb_node|
+          _, _, code_node, = *erb_node
+          stdout.puts code_node.loc.source
         end
       end
     end

--- a/lib/querly/pp/cli.rb
+++ b/lib/querly/pp/cli.rb
@@ -79,10 +79,13 @@ module Querly
         source_buffer = Parser::Source::Buffer.new('(erb)')
         source_buffer.source = source
         parser = BetterHtml::Parser.new(source_buffer, template_language: :html)
+
+        new_source = source.gsub(/./, ' ')
         parser.ast.descendants(:erb).each do |erb_node|
           _, _, code_node, = *erb_node
-          stdout.puts code_node.loc.source
+          new_source[code_node.loc.range] = code_node.loc.source
         end
+        stdout.puts new_source
       end
     end
   end


### PR DESCRIPTION
FYI
---

### Plain erb

I tried `erubis -X` and `erb -x` but It doesn't work well in following example.

```erb
<%= content_tag :div do %>
  bar
<% end %>
```

```
% erb -x foo.html.erb
#coding:ASCII-8BIT
_erbout = String.new; _erbout.concat(( content_tag :div do ).to_s); _erbout.concat "\n"
; _erbout.concat "  bar\n"
;  end ; _erbout.concat "\n"
; _erbout.force_encoding(__ENCODING__)
```

```
% erb -x foo.html.erb | ruby -c
-:2: syntax error, unexpected ')'
concat(( content_tag :div do ).to_s); _erbout.concat "\n"
                              ^
-:4: syntax error, unexpected keyword_end, expecting ')'
;  end ; _erbout.concat "\n"
      ^
-:5: syntax error, unexpected end-of-input, expecting ')'
```

### ActionView::Template::Handlers::ERB

It has some noise.

```rb
path = "foo.html.erb"
erb = File.read(path)
template = ActionView::Template.new(erb, path, ActionView::Template::Handlers::ERB.new, {})
puts template.handler.call(template)
# @output_buffer = output_buffer || ActionView::OutputBuffer.new;@output_buffer.append=  content_tag :div do @output_buffer.safe_append='
#   bar
# '.freeze; end
# @output_buffer.to_s
```