### PR TITLE
Relax racc dependency to fix build on Ruby trunk

### DIFF
--- a/querly.gemspec
+++ b/querly.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", ">= 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "racc", "= 1.4.14"
+  spec.add_development_dependency "racc", ">= 1.4.14"
   spec.add_development_dependency "unification_assertion", "0.0.1"
 
   spec.add_dependency 'thor', ">= 0.19.0", "< 0.21.0"


### PR DESCRIPTION
We cannot build racc v1.4.14 with Ruby trunk because of https://github.com/tenderlove/racc/pull/101 .
So I relaxed the racc dependency.



I introduced finxing version of rack in https://github.com/soutaro/querly/pull/1 .
I forget why I fixed it, but I think relaxed version is better :laughing: 


Thanks.