### PR TITLE
Allow underscore for method name with receiver

### DIFF
--- a/lib/querly/pattern/parser.y
+++ b/lib/querly/pattern/parser.y
@@ -72,7 +72,7 @@ keyword: LIDENT | UIDENT
 constant: UIDENT { result = [val[0]] }
   | UIDENT COLONCOLON constant { result = [val[0]] + val[2] }
 
-send: LIDENT block { result = val[1] != nil ? Expr::Send.new(receiver: nil, name: val[0], args: Argument::AnySeq.new, block: val[1]) : Expr::Vcall.new(name: val[0]) }
+send: LIDENT block { result = val[1] != nil ? Expr::Send.new(receiver: nil, name: val[0], block: val[1]) : Expr::Vcall.new(name: val[0]) }
   | UIDENT block { result = Expr::Send.new(receiver: nil, name: val[0], block: val[1]) }
   | method_name { result = Expr::Send.new(receiver: nil, name: val[0], block: nil) }
   | method_name_or_ident LPAREN args RPAREN block { result = Expr::Send.new(receiver: nil,
@@ -83,18 +83,15 @@ send: LIDENT block { result = val[1] != nil ? Expr::Send.new(receiver: nil, name
                                                                   name: val[1],
                                                                   args: Argument::AnySeq.new,
                                                                   block: val[2]) }
-  | receiver method_name_or_ident block { result = Expr::Send.new(receiver: val[0],
-                                                                  name: val[1],
-                                                                  args: Argument::AnySeq.new,
-                                                                  block: val[2]) }
   | receiver method_name_or_ident LPAREN args RPAREN block { result = Expr::Send.new(receiver: val[0],
                                                                                      name: val[1],
                                                                                      args: val[3],
                                                                                      block: val[5]) }
-  | receiver method_name_or_ident LPAREN args RPAREN block { result = Expr::Send.new(receiver: val[0],
-                                                                                     name: val[1],
-                                                                                     args: val[3],
-                                                                                     block: val[5]) }
+  | receiver UNDERBAR block { result = Expr::Send.new(receiver: val[0], name: /.+/, block: val[2]) }
+  | receiver UNDERBAR LPAREN args RPAREN block { result = Expr::Send.new(receiver: val[0],
+                                                                         name: /.+/,
+                                                                         args: val[3],
+                                                                         block: val[5]) }
 
 receiver: expr DOT { result = val[0] }
   | expr DOTDOTDOT { result = Expr::ReceiverContext.new(receiver: val[0]) }

--- a/test/pattern_parser_test.rb
+++ b/test/pattern_parser_test.rb
@@ -118,6 +118,30 @@ class PatternParserTest < Minitest::Test
     assert_equal [:F], parse_expr("_.F").name
   end
 
+  def test_any_method
+    recv = E::Vcall.new(name: :a)
+    assert_equal E::Send.new(receiver: recv,
+                             name: /.+/,
+                             args: A::AnySeq.new,
+                             block: nil), parse_expr("a._")
+    assert_equal E::Send.new(receiver: recv,
+                             name: /.+/,
+                             args: A::AnySeq.new,
+                             block: true), parse_expr("a._{}")
+    assert_equal E::Send.new(receiver: recv,
+                             name: /.+/,
+                             args: A::AnySeq.new,
+                             block: false), parse_expr("a._!{}")
+    assert_equal E::Send.new(receiver: recv,
+                             name: /.+/,
+                             args: nil,
+                             block: nil), parse_expr("a._()")
+    assert_equal E::Send.new(receiver: recv,
+                             name: /.+/,
+                             args: A::Expr.new(expr: E::Vcall.new(name: :b), tail: nil),
+                             block: nil), parse_expr("a._(b)")
+  end
+
   def test_method_name
     assert_equal [:f!], parse_expr("f!()").name
     assert_equal [:f=], parse_expr("f=(3)").name

--- a/test/pattern_test_test.rb
+++ b/test/pattern_test_test.rb
@@ -251,6 +251,24 @@ class PatternTestTest < Minitest::Test
     assert_equal ruby("bar.foo"), nodes.first
   end
 
+  def test_call_any_method
+    nodes = query_pattern("foo._", "foo; foo.bar; foo.baz")
+    assert_equal 2, nodes.size
+    assert_equal [ruby("foo.bar"), ruby("foo.baz")], nodes
+  end
+
+  def test_call_any_method_with_args
+    nodes = query_pattern("foo._(baz)", "foo.bar(baz); foo.bar(bar)")
+    assert_equal 1, nodes.size
+    assert_equal ruby("foo.bar(baz)"), nodes.first
+  end
+
+  def test_call_any_method_with_block
+    nodes = query_pattern("foo._{}", "foo.bar; foo.baz{}")
+    assert_equal 1, nodes.size
+    assert_equal ruby("foo.baz{}"), nodes.first
+  end
+
   def test_vcall
     # Vcall pattern matches with local variable
     nodes = query_pattern("foo", "foo = 1; foo.bar")


### PR DESCRIPTION
Problem
===

`_` matcher with method chain raises a syntax error.


example

```yaml
rules:
  - id: sample.abc
    pattern:
      - b._
    message: a
    examples:
      - before: 'b.c'
        after: 'b'
```
m
```console
$ querly test
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/parser-2.6.2.0/lib/parser/lexer.rb:10861: warning: assigned but unused variable - testEof
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/querly-0.15.1/lib/querly/node_pair.rb:28: warning: `&' interpreted as argument prefix
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/querly-0.15.1/lib/querly/pattern/parser.rb:825: warning: mismatched indentations at 'end' with 'module' at 9
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/querly-0.15.1/lib/querly/pattern/parser.rb:826: warning: mismatched indentations at 'end' with 'module' at 8
Fatal error:
#<Querly::Rule::PatternSyntaxError: Pattern syntax error: rule=sample.abc, index=0, pattern=b._, where={}: 
parse error on value "_" (UNDERBAR)>
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/querly-0.15.1/lib/querly/rule.rb:86:in `rescue in block in load'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/querly-0.15.1/lib/querly/rule.rb:83:in `block in load'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/querly-0.15.1/lib/querly/rule.rb:73:in `map'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/querly-0.15.1/lib/querly/rule.rb:73:in `with_index'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/querly-0.15.1/lib/querly/rule.rb:73:in `load'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/querly-0.15.1/lib/querly/config.rb:62:in `block in config'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/querly-0.15.1/lib/querly/config.rb:62:in `map'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/querly-0.15.1/lib/querly/config.rb:62:in `config'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/querly-0.15.1/lib/querly/config.rb:18:in `load'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/querly-0.15.1/lib/querly/cli/test.rb:156:in `load_config'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/querly-0.15.1/lib/querly/cli/test.rb:24:in `run'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/querly-0.15.1/lib/querly/cli.rb:100:in `test'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
  /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/querly-0.15.1/exe/querly:8:in `<top (required)>'
  /home/pocke/.rbenv/versions/trunk/bin/querly:23:in `load'
  /home/pocke/.rbenv/versions/trunk/bin/querly:23:in `<main>'
```

I think it is useful if it allows `_` in method chain.

link: https://mobile.twitter.com/hanachin_/status/1113674668815159297



Goal
===

- [x] Allow `_` in method chain, without args, without block. It means it supports only most simple case.
- [x] Support more syntax
  - like `foo._(arg)`, block, etc
- [x] Add test

---

cc: @hanachin
