### PR TITLE
Support string literal in pattern

### DIFF
--- a/lib/querly/pattern/parser.y
+++ b/lib/querly/pattern/parser.y
@@ -133,6 +133,8 @@ def next_token
     [:NIL, false]
   when input.scan(/:string:/)
     [:STRING, nil]
+  when input.scan(/"([^"]+)"/)
+    [:STRING, input[1]]
   when input.scan(/:dstr:/)
     [:DSTR, nil]
   when input.scan(/:int:/)

--- a/manual/patterns.md
+++ b/manual/patterns.md
@@ -71,6 +71,8 @@ bar.foo.baz               # foo...bar...baz does not match
 * `1.23` (float)
 * `:foobar` (symbol)
 * `:symbol:` (any symbol literal)
+* `"foobar"` (string)
+    * NOTE: It only supports double quotation.
 * `:string:` (any string literal)
 * `:dstr:` (any dstr `"hi #{name}"`)
 * `true`, `false` (true and false)
@@ -145,7 +147,7 @@ end
 
 # Interpolation Syntax
 
-If you want to describe a pattern that can not be described with adove syntax, you can use interpolation as follows:
+If you want to describe a pattern that can not be described with above syntax, you can use interpolation as follows:
 
 ```yaml
 id: find_by_abc_and_def

--- a/test/pattern_parser_test.rb
+++ b/test/pattern_parser_test.rb
@@ -246,6 +246,22 @@ class PatternParserTest < Minitest::Test
     assert_equal ["foo"], pat.values
   end
 
+  def test_string_literal
+    pat = parse_expr('"foo"')
+    assert_instance_of E::Literal, pat
+    assert_equal :string, pat.type
+    assert_equal ["foo"], pat.values
+  end
+
+  def test_string_literal_with_backslash_escape
+    skip("Implement escape sequence in the future")
+
+    pat = parse_expr('"foo\n"')
+    assert_instance_of E::Literal, pat
+    assert_equal :string, pat.type
+    assert_equal ["foo\n"], pat.values
+  end
+
   def test_as_something
     pat = parse_expr("assert()")
     assert_instance_of E::Send, pat


### PR DESCRIPTION
It will support string literal pattern.

e.g.

```yaml
pattern: 'require("active_support")'
```

It is useful for a shorthand of `:string: as 'name` and `where`. And we will be able to search with string literal in querly console by this feature.

Note: It will support really simple string. It means it does not the same as Ruby's one.
But I think it is enough for 95% cases. It should have more features, such as backslash escape, but it is enough for the first step.

Note 2: It only supports double quotation, because interpolation syntax already uses single quotation.

Note 3: Symbol literals is already supported! :tada:
https://github.com/pocke/querly/blob/21194401babfa918fa62160993db7111a478017e/lib/querly/pattern/parser.y#L152-L154


Goal
===


* [x] implement
* [x] add test
* [x] add document