### PR TITLE
Add `Script.load`

### DIFF
--- a/lib/querly/script.rb
+++ b/lib/querly/script.rb
@@ -3,6 +3,16 @@ module Querly
     attr_reader :path
     attr_reader :node
 
+    def self.load(path:, source:)
+      parser = Parser::Ruby25.new(Builder.new).tap do |parser|
+        parser.diagnostics.all_errors_are_fatal = true
+        parser.diagnostics.ignore_warnings = true
+      end
+      buffer = Parser::Source::Buffer.new(path.to_s, 1)
+      buffer.source = source
+      self.new(path: path, node: parser.parse(buffer))
+    end
+
     def initialize(path:, node:)
       @path = path
       @node = node
@@ -10,6 +20,16 @@ module Querly
 
     def root_pair
       NodePair.new(node: node)
+    end
+
+    class Builder < Parser::Builders::Default
+      def string_value(token)
+        value(token)
+      end
+
+      def emit_lambda
+        true
+      end
     end
   end
 end

--- a/lib/querly/script_enumerator.rb
+++ b/lib/querly/script_enumerator.rb
@@ -45,21 +45,12 @@ module Querly
                    path.read
                  end
 
-        buffer = Parser::Source::Buffer.new(path.to_s, 1)
-        buffer.source = source
-        script = Script.new(path: path, node: parser.parse(buffer))
+        script = Script.load(path: path, source: source)
       rescue StandardError, LoadError, Preprocessor::Error => exn
         script = exn
       end
 
       yield(path, script)
-    end
-
-    def parser
-      Parser::Ruby25.new(Builder.new).tap do |parser|
-        parser.diagnostics.all_errors_are_fatal = true
-        parser.diagnostics.ignore_warnings = true
-      end
     end
 
     def preprocessors
@@ -99,16 +90,6 @@ module Querly
                            end
 
         load_script_from_path(path, &block) if should_load_file
-      end
-    end
-
-    class Builder < Parser::Builders::Default
-      def string_value(token)
-        value(token)
-      end
-
-      def emit_lambda
-        true
       end
     end
   end


### PR DESCRIPTION
Add a new class method `Querly::Script.load`.

## Motivation

Currently, Querly's Ruby parser depends on `Querly::ScriptEnumerator`. There are no problems in many cases, but it will be a concern when using Querly as a library (imagine call Querly's internal API from **another** Ruby application).

Because of this problem, it makes the parser dependent on the `Script`, not the `ScriptEnumerator`.