### PR TITLE
`console` and `find` with configuration file

### DIFF
--- a/lib/querly/cli/console.rb
+++ b/lib/querly/cli/console.rb
@@ -8,12 +8,14 @@ module Querly
       attr_reader :paths
       attr_reader :history_path
       attr_reader :history_size
+      attr_reader :config
       attr_reader :history
 
-      def initialize(paths:, history_path:, history_size:)
+      def initialize(paths:, history_path:, history_size:, config: nil)
         @paths = paths
         @history_path = history_path
         @history_size = history_size
+        @config = config
         @history = []
       end
 
@@ -42,9 +44,9 @@ Querly #{VERSION}, interactive console
       def analyzer
         return @analyzer if @analyzer
 
-        @analyzer = Analyzer.new(config: nil, rule: nil)
+        @analyzer = Analyzer.new(config: config, rule: nil)
 
-        ScriptEnumerator.new(paths: paths, config: nil).each do |path, script|
+        ScriptEnumerator.new(paths: paths, config: config).each do |path, script|
           case script
           when Script
             @analyzer.scripts << script

--- a/lib/querly/cli/find.rb
+++ b/lib/querly/cli/find.rb
@@ -7,10 +7,12 @@ module Querly
 
       attr_reader :pattern_str
       attr_reader :paths
+      attr_reader :config
 
-      def initialize(pattern:, paths:)
+      def initialize(pattern:, paths:, config: nil)
         @pattern_str = pattern
         @paths = paths
+        @config = config
       end
 
       def start
@@ -48,9 +50,9 @@ module Querly
       def analyzer
         return @analyzer if @analyzer
 
-        @analyzer = Analyzer.new(config: nil, rule: nil)
+        @analyzer = Analyzer.new(config: config, rule: nil)
 
-        ScriptEnumerator.new(paths: paths, config: nil).each do |path, script|
+        ScriptEnumerator.new(paths: paths, config: config).each do |path, script|
           case script
           when Script
             @analyzer.scripts << script


### PR DESCRIPTION
# problem


Currenly `querly console` and `querly find` commands do not read the configuration file.
So they are not aware of the preprocessor config.
Querly does not look `.haml` files even if it's with the following configuration.


```yaml
preprocessor:
  .haml: hamlit compile -
```


# Solution



Pass config to console and find.