### PR TITLE
Enumerate scripts in parallel

### DIFF
--- a/lib/querly.rb
+++ b/lib/querly.rb
@@ -5,6 +5,7 @@ require "parser/ruby25"
 require "set"
 require "open3"
 require "active_support/inflector"
+require "parallel"
 
 require "querly/version"
 require 'querly/analyzer'

--- a/lib/querly/cli/console.rb
+++ b/lib/querly/cli/console.rb
@@ -10,13 +10,15 @@ module Querly
       attr_reader :history_size
       attr_reader :config
       attr_reader :history
+      attr_reader :threads
 
-      def initialize(paths:, history_path:, history_size:, config: nil)
+      def initialize(paths:, history_path:, history_size:, config: nil, threads:)
         @paths = paths
         @history_path = history_path
         @history_size = history_size
         @config = config
         @history = []
+        @threads = threads
       end
 
       def start
@@ -46,7 +48,7 @@ Querly #{VERSION}, interactive console
 
         @analyzer = Analyzer.new(config: config, rule: nil)
 
-        ScriptEnumerator.new(paths: paths, config: config).each do |path, script|
+        ScriptEnumerator.new(paths: paths, config: config, threads: threads).each do |path, script|
           case script
           when Script
             @analyzer.scripts << script

--- a/lib/querly/cli/find.rb
+++ b/lib/querly/cli/find.rb
@@ -8,11 +8,13 @@ module Querly
       attr_reader :pattern_str
       attr_reader :paths
       attr_reader :config
+      attr_reader :threads
 
-      def initialize(pattern:, paths:, config: nil)
+      def initialize(pattern:, paths:, config: nil, threads:)
         @pattern_str = pattern
         @paths = paths
         @config = config
+        @threads = threads
       end
 
       def start
@@ -38,7 +40,7 @@ module Querly
         puts "#{count} results"
       rescue => exn
         STDOUT.puts Rainbow("Error: #{exn}").red
-        STDTOU.puts "pattern: #{pattern_str}"
+        STDOUT.puts "pattern: #{pattern_str}"
         STDOUT.puts "Backtrace:"
         STDOUT.puts format_backtrace(exn.backtrace)
       end
@@ -52,7 +54,7 @@ module Querly
 
         @analyzer = Analyzer.new(config: config, rule: nil)
 
-        ScriptEnumerator.new(paths: paths, config: config).each do |path, script|
+        ScriptEnumerator.new(paths: paths, config: config, threads: threads).each do |path, script|
           case script
           when Script
             @analyzer.scripts << script

--- a/querly.gemspec
+++ b/querly.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "parser", ">= 2.5.0"
   spec.add_dependency "rainbow", ">= 2.1"
   spec.add_dependency "activesupport", ">= 5.0"
+  spec.add_dependency "parallel", "~>1.17"
 end

--- a/test/script_enumerator_test.rb
+++ b/test/script_enumerator_test.rb
@@ -9,7 +9,7 @@ class ScriptEnumeratorTest < Minitest::Test
   def test_parsing_ruby
     mktmpdir do |dir|
       config = Config.new(rules: [], preprocessors: {}, root_dir: dir, checks: [])
-      e = ScriptEnumerator.new(paths: nil, config: config)
+      e = ScriptEnumerator.new(paths: nil, config: config, threads: 1)
 
       ruby_path = dir + "foo.rb"
       ruby_path.write <<-EOR
@@ -27,7 +27,7 @@ end
   def test_parse_error_ruby
     mktmpdir do |dir|
       config = Config.new(rules: [], preprocessors: {}, root_dir: dir, checks: [])
-      e = ScriptEnumerator.new(paths: nil, config: config)
+      e = ScriptEnumerator.new(paths: nil, config: config, threads: 1)
 
       ruby_path = dir + "foo.rb"
       ruby_path.write <<-EOR
@@ -44,7 +44,7 @@ def foo()
   def test_no_parse_error_on_invalid_utf8_sequence
     mktmpdir do |dir|
       config = Config.new(rules: [], preprocessors: {}, root_dir: dir, checks: [])
-      e = ScriptEnumerator.new(paths: nil, config: config)
+      e = ScriptEnumerator.new(paths: nil, config: config, threads: 1)
 
       ruby_path = dir + "foo.rb"
       ruby_path.write '"\xFF"'


### PR DESCRIPTION
Using `parallel` gem, `ScriptEnumerator#each` yields `Script` objects concurrently, in threads. You can specify `--threads` command line option for `check`, `console`, and `find` commands.

If your config has preprocessor definition and your source files contain many preprocessed files, this patch improves the performance up to ~#of threads in your processor. I tested on my Core i5, 4 threads iMac, `--threads=4` runs about three times faster than `--threads=1` for HAML files.