### PR TITLE
Add Ruby 2.7 and update supported Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
 before_install: gem install bundler
 script:
   - bundle exec rake test


### PR DESCRIPTION
I've tested Querly with Ruby 2.7.1 on my local machine and there are no problems.