### PR TITLE
Fix invalid bytes sequence in UTF-8 error

### DIFF
--- a/lib/querly/pattern/expr.rb
+++ b/lib/querly/pattern/expr.rb
@@ -118,7 +118,7 @@ module Querly
 
           when :str
             return false unless type == :string
-            test_value(node.children.first)
+            test_value(node.children.first.scrub)
 
           when :sym
             return false unless type == :symbol

--- a/test/pattern_test_test.rb
+++ b/test/pattern_test_test.rb
@@ -101,6 +101,12 @@ class PatternTestTest < Minitest::Test
     refute nodes.test_node(ruby('"baz"'))
   end
 
+  def test_byte_sequence_string
+    nodes = E::Literal.new(type: :string, values: [/foo/])
+    assert nodes.test_node(ruby('"\xfffoo"'))
+    refute nodes.test_node(ruby('"\xffbaz"'))
+  end
+
   def test_regexp
     nodes = query_pattern(":regexp:", '[/1/, /#{2}/, 3]')
     assert_equal 2, nodes.size

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,7 +38,7 @@ module TestHelper
   end
 
   def ruby(src)
-    Parser::Ruby25.parse(src)
+    Querly::Script.load(path: "(input)", source: src).node
   end
 
   def with_config(hash)


### PR DESCRIPTION
I found `invalid byte sequence in UTF-8 error` error is raised with my source code.
If source contains byte sequence string literal like `"\xff"` and rule uses regexp like `/foo/`, the error raises.
This PR will fix it.

#### querly.yml
```yaml:querly.yml
rules:
  - id: do_not_use_foo
    pattern:
      subject: ":string: as 'str"
      where:
        str: /foo/
    message: Do not use foo.
```

#### target.rb
```ruby:target.rb
"\xff"
```

