### PR TITLE
Fix Ruby warnings

### DIFF
--- a/lib/querly/node_pair.rb
+++ b/lib/querly/node_pair.rb
@@ -25,7 +25,7 @@ module Querly
         yield self
 
         children.each do |child|
-          child.each_subpair &block
+          child.each_subpair(&block)
         end
       else
         enum_for :each_subpair

--- a/test/cli/console_test.rb
+++ b/test/cli/console_test.rb
@@ -61,27 +61,27 @@ end
         write.puts "find create!"
         read.gets
         output = read_for(read, pattern: /^> $/)
-        assert_match /#{Regexp.escape "User.create!(params[:user])"}/, output
+        assert_match %r/#{Regexp.escape "User.create!(params[:user])"}/, output
 
         write.puts "find redirect_to"
         read.gets
         output = read_for(read, pattern: /^> $/)
-        assert_match /#{Regexp.escape "redirect_to user_path(user)"}/, output
+        assert_match %r/#{Regexp.escape "redirect_to user_path(user)"}/, output
 
         write.puts "find User.find_each"
         read.gets
         output = read_for(read, pattern: /^> $/)
-        assert_match /#{Regexp.escape "0 results"}/, output
+        assert_match %r/#{Regexp.escape "0 results"}/, output
 
         write.puts "find crea te !!"
         read.gets
         output = read_for(read, pattern: /^> $/)
-        assert_match /#{Regexp.escape "parse error on value"}/, output
+        assert_match %r/#{Regexp.escape "parse error on value"}/, output
 
         write.puts "no such command"
         read.gets
         output = read_for(read, pattern: /^> $/)
-        assert_match /#{Regexp.escape "Commands:"}/, output
+        assert_match %r/#{Regexp.escape "Commands:"}/, output
 
         write.puts "quit"
         read.gets
@@ -101,7 +101,7 @@ end
         write.puts "find create!"
         read.gets
         output = read_for(read, pattern: /^> $/)
-        assert_match /#{Regexp.escape "User.create!(params[:user])"}/, output
+        assert_match %r/#{Regexp.escape "User.create!(params[:user])"}/, output
 
         write.puts "exit"
         read.gets
@@ -133,7 +133,7 @@ end
         write.puts "find create!"
         read.gets
         output = read_for(read, pattern: /^> $/)
-        assert_match /#{Regexp.escape "User.create!(params[:user])"}/, output
+        assert_match %r/#{Regexp.escape "User.create!(params[:user])"}/, output
 
         write.puts "quit"
         read.gets

--- a/test/cli/test_test.rb
+++ b/test/cli/test_test.rb
@@ -21,7 +21,7 @@ class TestTest < Minitest::Test
     result = test.run
 
     assert_equal 1, result
-    assert_match /There is nothing to test at querly\.yaml/, stdout.string
+    assert_match %r/There is nothing to test at querly\.yaml/, stdout.string
   end
 
   def test_rule_uniqueness
@@ -46,8 +46,8 @@ class TestTest < Minitest::Test
     result = test.run
 
     assert_equal 1, result
-    assert_match /Rule id id1 duplicated!/, stdout.string
-    refute_match /Rule id id2 duplicated!/, stdout.string
+    assert_match %r/Rule id id1 duplicated!/, stdout.string
+    refute_match %r/Rule id id2 duplicated!/, stdout.string
   end
 
   def test_rule_patterns_pass
@@ -78,7 +78,7 @@ class TestTest < Minitest::Test
     result = test.run
 
     assert_equal 0, result
-    assert_match /All tests green!/, stdout.string
+    assert_match %r/All tests green!/, stdout.string
   end
 
   def test_rule_patterns_before_after_fail
@@ -109,10 +109,10 @@ class TestTest < Minitest::Test
     result = test.run
 
     assert_equal 1, result
-    assert_match /id1:\t1st \*before\* example didn't match with any pattern/, stdout.string
-    assert_match /id1:\t1st \*after\* example matched with some of patterns/, stdout.string
-    assert_match /1 examples found which should not match, but matched/, stdout.string
-    assert_match /1 examples found which should match, but didn't/, stdout.string
+    assert_match %r/id1:\t1st \*before\* example didn't match with any pattern/, stdout.string
+    assert_match %r/id1:\t1st \*after\* example matched with some of patterns/, stdout.string
+    assert_match %r/1 examples found which should not match, but matched/, stdout.string
+    assert_match %r/1 examples found which should match, but didn't/, stdout.string
   end
 
   def test_rule_patterns_example_fail
@@ -144,10 +144,10 @@ class TestTest < Minitest::Test
     result = test.run
 
     assert_equal 1, result
-    assert_match /id1:\tafter of 1st example matched with some of patterns/, stdout.string
-    assert_match /id1:\tbefore of 2nd example didn't match with any pattern/, stdout.string
-    assert_match /1 examples found which should not match, but matched/, stdout.string
-    assert_match /1 examples found which should match, but didn't/, stdout.string
+    assert_match %r/id1:\tafter of 1st example matched with some of patterns/, stdout.string
+    assert_match %r/id1:\tbefore of 2nd example didn't match with any pattern/, stdout.string
+    assert_match %r/1 examples found which should not match, but matched/, stdout.string
+    assert_match %r/1 examples found which should match, but didn't/, stdout.string
   end
 
   def test_rule_patterns_error
@@ -174,6 +174,6 @@ class TestTest < Minitest::Test
     result = test.run
 
     assert_equal 1, result
-    assert_match /2 examples raised error/, stdout.string
+    assert_match %r/2 examples raised error/, stdout.string
   end
 end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -57,7 +57,7 @@ class ConfigTest < Minitest::Test
   def test_factory_config_prints_warning_on_tagging
     Config::Factory.new({ "tagging" => [] }, config_path: Pathname("/foo/bar"), root_dir: Pathname("/foo/bar"), stderr: stderr).config
 
-    assert_match /tagging is deprecated and ignored/, stderr.string
+    assert_match %r/tagging is deprecated and ignored/, stderr.string
   end
 
   def test_relative_path_from_root


### PR DESCRIPTION
https://github.com/soutaro/querly/runs/681068886?check_suite_focus=true#step:4:149

```
/__w/querly/querly/lib/querly/node_pair.rb:28: warning: `&' interpreted as argument prefix
/__w/querly/querly/test/cli/console_test.rb:64: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/console_test.rb:69: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/console_test.rb:74: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/console_test.rb:79: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/console_test.rb:84: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/console_test.rb:104: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/console_test.rb:136: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/test_test.rb:24: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/test_test.rb:49: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/test_test.rb:50: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/test_test.rb:81: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/test_test.rb:112: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/test_test.rb:113: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/test_test.rb:114: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/test_test.rb:115: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/test_test.rb:147: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/test_test.rb:148: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/test_test.rb:149: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/test_test.rb:150: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/cli/test_test.rb:177: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/__w/querly/querly/test/config_test.rb:60: warning: ambiguous first argument; put parentheses or a space even after `/' operator
```