### PR TITLE
Run rubocop-rubycw to prevent Ruby warnings

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,18 @@
+name: RuboCop
+
+on: pull_request
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+    - run: gem install rubocop rubocop-rubycw --no-document
+    - name: Run RuboCop
+      shell: bash
+      run: |
+        # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
+        rubocop | ruby -pe 'sub(/^(.+):(\d+):(\d+): (.): (.+)$/, %q{::error file=\1,line=\2,col=\3::\5})'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,10 @@
+require:
+  - rubocop-rubycw
+
+AllCops:
+  DisabledByDefault: true
+  Exclude:
+    - test/data/**/*.rb
+
+Rubycw/Rubycw:
+  Enabled: true

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ task :default => :test
 task :build => :racc
 task :test => :racc
 
-rule /\.rb/ => ".y" do |t|
+rule %r/\.rb/ => ".y" do |t|
   sh "racc", "-v", "-o", "#{t.name}", "#{t.source}"
 end
 


### PR DESCRIPTION
This change aims to prevent unexpected Ruby warnings such as #80.

See also:

- https://github.com/rubocop-hq/rubocop-rubycw
- https://github.com/soutaro/querly/pull/80#issuecomment-653579050
- https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message