### PR TITLE
Show diagnostic info on syntax error

### DIFF
--- a/lib/querly/cli/formatter.rb
+++ b/lib/querly/cli/formatter.rb
@@ -46,7 +46,12 @@ module Querly
 
         def script_error(path, error)
           STDERR.puts Rainbow("Failed to load script: #{path}").red
-          STDERR.puts error.inspect
+
+          if error.is_a? Parser::SyntaxError
+            STDERR.puts error.diagnostic.render
+          else
+            STDERR.puts error.inspect
+          end
         end
 
         def issue_found(script, rule, pair)

--- a/test/smoke_test.rb
+++ b/test/smoke_test.rb
@@ -236,4 +236,19 @@ class SmokeTest < Minitest::Test
       end
     end
   end
+
+  def test_check_text_format_when_syntax_error
+    push_dir root + "test/data/test2" do
+      out, err, status = sh(querly_path.to_s, "check", "--format=text", ".")
+
+      assert status.success?
+      assert_empty out
+      assert_equal [
+        "Failed to load script: script.rb\n",
+        "script.rb:2:1: error: unexpected token $end\n",
+        "script.rb:2: \n",
+        "script.rb:2: \n",
+      ].join, err
+    end
+  end
 end


### PR DESCRIPTION
When checking a big file, I sometimes have been hard to find where a syntax error occurs.
Perhaps, this change can help users find and report a problem such as #78 more easily.

Before:

```console
$ querly check foo.rb
Failed to load script: foo.rb
#<Parser::SyntaxError: unexpected token $end>
```

After:

```console
$ querly check foo.rb
Failed to load script: foo.rb
foo.rb:2:1: error: unexpected token $end
foo.rb:2:
foo.rb:2:
```