### PR TITLE
Fix erb comment preprocess

### DIFF
--- a/lib/querly/pp/cli.rb
+++ b/lib/querly/pp/cli.rb
@@ -82,7 +82,8 @@ module Querly
 
         new_source = source.gsub(/./, ' ')
         parser.ast.descendants(:erb).each do |erb_node|
-          _, _, code_node, = *erb_node
+          indicator_node, _, code_node, = *erb_node
+          next if indicator_node&.loc&.source == '#'
           new_source[code_node.loc.range] = code_node.loc.source
           new_source[code_node.loc.range.end] = ';'
         end


### PR DESCRIPTION
I found that `querly-pp erb` pre-process comments in *.erb wrongly.

```
$ cat foo.erb
<%# ] %>

$ querly-pp erb < foo.erb
    ] ;
```
`querly-pp erb` can output invalid syntax ruby codes.

This PR will fix it.

### Environment

```
$ querly version
Querly 1.1.0
```