### PR TITLE
Relax Thor version

### DIFF
--- a/querly.gemspec
+++ b/querly.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "slim", "~> 4.0.1"
   spec.add_development_dependency "haml", "~> 5.0.4"
 
-  spec.add_dependency 'thor', ">= 0.19.0", "< 0.21.0"
+  spec.add_dependency 'thor', ">= 0.19.0"
   spec.add_dependency "parser", ">= 2.5.0"
   spec.add_dependency "rainbow", ">= 2.1"
   spec.add_dependency "activesupport", ">= 5.0"


### PR DESCRIPTION
Rails 6.1.0 depends on Thor `"~> 1.0"`. So this fix is required to use Querly with Rails 6.1.0.
https://github.com/rails/rails/blob/8fd81f4980b76c4dbf0d0323482bc55e20bff308/railties/railties.gemspec#L43

By the way, Thor 1.0.0 doesn't have breaking changes. So we can upgrade
to Thor 1.0.0 without code changes.
https://github.com/erikhuda/thor/blob/master/CHANGELOG.md#100