### PR TITLE
Update RuboCop action

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -9,10 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
-    - run: gem install rubocop rubocop-rubycw --no-document
+        ruby-version: "3.0"
+    - run: gem install rubocop rubocop-rubycw
     - name: Run RuboCop
-      shell: bash
-      run: |
-        # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
-        rubocop | ruby -pe 'sub(/^(.+):(\d+):(\d+): (.): (.+)$/, %q{::error file=\1,line=\2,col=\3::\5})'
+      run: rubocop --format github


### PR DESCRIPTION
- Use the built-in GitHub Actions formatted.
  See <https://docs.rubocop.org/rubocop/1.11/formatters.html#github-actions-formatter>
- Use Ruby 3.0 (latest)