### PR TITLE
Require Ruby 3.0 and 2.7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,15 +8,15 @@ on:
 
 jobs:
   test:
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.6, 2.7, head]
+        ruby: ["2.7", "3.0", head]
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - run: bundle install --jobs 4 --retry 3
+        bundler-cache: true
     - run: bin/setup
     - run: bundle exec rake build test

--- a/lib/querly.rb
+++ b/lib/querly.rb
@@ -1,7 +1,7 @@
 require 'pathname'
 require "yaml"
 require "rainbow"
-require "parser/ruby25"
+require "parser/ruby30"
 require "set"
 require "open3"
 require "active_support/inflector"

--- a/lib/querly/cli/test.rb
+++ b/lib/querly/cli/test.rb
@@ -140,7 +140,7 @@ module Querly
 
         found = false
 
-        node = Parser::Ruby25.parse(example)
+        node = Parser::Ruby30.parse(example)
         NodePair.new(node: node).each_subpair do |pair|
           if analyzer.test_pair(pair, pattern)
             found = true

--- a/lib/querly/script.rb
+++ b/lib/querly/script.rb
@@ -4,7 +4,7 @@ module Querly
     attr_reader :node
 
     def self.load(path:, source:)
-      parser = Parser::Ruby25.new(Builder.new).tap do |parser|
+      parser = Parser::Ruby30.new(Builder.new).tap do |parser|
         parser.diagnostics.all_errors_are_fatal = true
         parser.diagnostics.ignore_warnings = true
       end

--- a/querly.gemspec
+++ b/querly.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.7"
+
   spec.add_development_dependency "bundler", ">= 1.12"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
@@ -32,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "haml", "~> 5.0.4"
 
   spec.add_dependency 'thor', ">= 0.19.0"
-  spec.add_dependency "parser", ">= 2.5.0"
+  spec.add_dependency "parser", ">= 3.0"
   spec.add_dependency "rainbow", ">= 2.1"
   spec.add_dependency "activesupport", ">= 5.0"
   spec.add_dependency "parallel", "~>1.17"

--- a/test/data/test4/querly.yml
+++ b/test/data/test4/querly.yml
@@ -1,0 +1,4 @@
+rules:
+  - id: test_rule
+    message: This is a test message
+    pattern: _.test

--- a/test/data/test4/script.rb
+++ b/test/data/test4/script.rb
@@ -1,0 +1,32 @@
+array = [1, 2, 3]
+
+# Endless range since Ruby 2.6
+array[1..]
+
+# Beginless range since Ruby 2.7
+array[..1]
+
+# Numbered block parameters since Ruby 2.7
+array.map { _1**2 }
+
+# Pattern matching since Ruby 2.7
+case array
+in [a, *]
+  puts a
+end
+
+# Arguments forwarding since Ruby 2.7
+def foo(...)
+  bar(...)
+end
+
+# Extended arguments forwarding since Ruby 3.0
+def foo2(a, ...)
+  bar2(a, ...)
+end
+
+# One-line pattern matching since Ruby 3.0
+{ a: 1, b: 2, c: 3 } => hash
+
+# Endless method definition since Ruby 3.0
+def square(x) = x * x

--- a/test/smoke_test.rb
+++ b/test/smoke_test.rb
@@ -251,4 +251,14 @@ class SmokeTest < Minitest::Test
       ].join, err
     end
   end
+
+  def test_check_new_syntax
+    push_dir root + "test/data/test4" do
+      out, err, status = sh(querly_path.to_s, "check", ".")
+
+      assert status.success?
+      assert_empty out
+      assert_empty err
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,7 +28,7 @@ module TestHelper
 
     analyzer = Querly::Analyzer.new(config: nil, rule: nil)
     analyzer.scripts << Querly::Script.new(path: Pathname("(input)"),
-                                           node: Parser::Ruby25.parse(src, "(input)"))
+                                           node: Parser::Ruby30.parse(src, "(input)"))
 
     [].tap do |result|
       analyzer.find(pat) do |script, pair|


### PR DESCRIPTION
This change aims to support newer Rubies 3.0 and 2.7.
Also, this requires Ruby 2.7 or newer (**breaking change**).

Close #78