### PR TITLE
Fix error on block pattern and method call without receiver

### DIFF
--- a/lib/querly/pattern/expr.rb
+++ b/lib/querly/pattern/expr.rb
@@ -171,12 +171,13 @@ module Querly
         end
 
         def test_node(node)
+          return false unless node
           return false if block == true && node.type != :block
           return false if block == false && node.type == :block
 
-          node = node.children.first if node&.type == :block
+          node = node.children.first if node.type == :block
 
-          case node&.type
+          case node.type
           when :send, :csend
             return false unless test_name(node)
             return false unless test_receiver(node.children[0])


### PR DESCRIPTION
A block pattern raises an error on a method call without the receiver.

For example:

```console
$ cat test.rb
foo

$ querly find a{}.foo
Error: undefined method `type' for nil:NilClass
pattern: a{}.foo
Backtrace:
  /path/to/querly-1.3.0/lib/querly/pattern/expr.rb:174:in `test_node'
  /path/to/querly-1.3.0/lib/querly/pattern/expr.rb:195:in `test_receiver'
  /path/to/querly-1.3.0/lib/querly/pattern/expr.rb:182:in `test_node'
  /path/to/querly-1.3.0/lib/querly/pattern/expr.rb:159:in `=~'
  /path/to/querly-1.3.0/lib/querly/analyzer.rb:42:in `test_pair'
  /path/to/querly-1.3.0/lib/querly/analyzer.rb:34:in `block (2 levels) in find'
  /path/to/querly-1.3.0/lib/querly/node_pair.rb:25:in `each_subpair'
  /path/to/querly-1.3.0/lib/querly/analyzer.rb:33:in `block in find'
  /path/to/querly-1.3.0/lib/querly/analyzer.rb:32:in `each'
  /path/to/querly-1.3.0/lib/querly/analyzer.rb:32:in `find'
  /path/to/querly-1.3.0/lib/querly/cli/find.rb:23:in `start'
  /path/to/querly-1.3.0/lib/querly/cli.rb:104:in `find'
  /path/to/thor-1.2.1/lib/thor/command.rb:27:in `run'
  /path/to/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
  /path/to/thor-1.2.1/lib/thor.rb:392:in `dispatch'
  /path/to/thor-1.2.1/lib/thor/base.rb:485:in `start'
  /path/to/querly-1.3.0/exe/querly:8:in `<top (required)>'
  /path/to/bin/querly:25:in `load'
  /path/to/bin/querly:25:in `<main>'
```

This patch fixes this problem